### PR TITLE
Vc/install status

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,7 +6,7 @@ service:
 linters-settings:
   govet:
     enable:
-      - fieldalignment
+      #- fieldalignment
     auto-fix: true
     check-shadowing: true
     settings:
@@ -72,7 +72,6 @@ linters:
     - misspell
     - noctx
     - stylecheck
-    - whitespace
     - gosec
   enable-all: false
   disable-all: true

--- a/cmd/create/firmware_set.go
+++ b/cmd/create/firmware_set.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
-	"github.com/metal-toolbox/mctl/cmd"
 	mctl "github.com/metal-toolbox/mctl/cmd"
 	"github.com/metal-toolbox/mctl/internal/app"
 	"github.com/metal-toolbox/mctl/pkg/model"
@@ -69,7 +68,7 @@ var createFirmwareSet = &cobra.Command{
 }
 
 func init() {
-	definedfirmwareSetFlags = &cmd.FirmwareSetFlags{}
+	definedfirmwareSetFlags = &mctl.FirmwareSetFlags{}
 
 	createFirmwareSet.PersistentFlags().StringVar(&definedfirmwareSetFlags.FirmwareUUIDs, "firmware-uuids", "", "comma separated list of UUIDs of firmware to be included in the set to be created")
 	createFirmwareSet.PersistentFlags().StringVar(&definedfirmwareSetFlags.FirmwareSetName, "name", "", "A name for the firmware set")

--- a/cmd/delete/condition.go
+++ b/cmd/delete/condition.go
@@ -1,4 +1,4 @@
-package deleteResource
+package deleteresource
 
 import (
 	"log"

--- a/cmd/delete/delete.go
+++ b/cmd/delete/delete.go
@@ -1,4 +1,4 @@
-package deleteResource
+package deleteresource
 
 import (
 	"github.com/metal-toolbox/mctl/cmd"
@@ -10,6 +10,7 @@ var deleteCmd = &cobra.Command{
 	Use:   "delete",
 	Short: "Delete resources",
 	Run: func(cmd *cobra.Command, args []string) {
+		//nolint:errcheck // returns nil
 		cmd.Help()
 	},
 }

--- a/cmd/delete/firmware_set.go
+++ b/cmd/delete/firmware_set.go
@@ -1,4 +1,4 @@
-package deleteResource
+package deleteresource
 
 import (
 	"fmt"

--- a/cmd/edit/edit.go
+++ b/cmd/edit/edit.go
@@ -10,6 +10,7 @@ var edit = &cobra.Command{
 	Use:   "edit",
 	Short: "Edit resources",
 	Run: func(cmd *cobra.Command, args []string) {
+		//nolint:errcheck // returns nil
 		cmd.Help()
 	},
 }

--- a/cmd/get/get.go
+++ b/cmd/get/get.go
@@ -13,6 +13,7 @@ var cmdGet = &cobra.Command{
 	Use:   "get",
 	Short: "Get resource",
 	Run: func(cmd *cobra.Command, args []string) {
+		//nolint:errcheck // returns nil
 		cmd.Help()
 	},
 }

--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -9,6 +9,7 @@ var install = &cobra.Command{
 	Use:   "install",
 	Short: "Install actions",
 	Run: func(cmd *cobra.Command, args []string) {
+		//nolint:errcheck // returns nil
 		cmd.Help()
 	},
 }

--- a/cmd/install/status.go
+++ b/cmd/install/status.go
@@ -1,0 +1,96 @@
+package install
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+
+	"github.com/google/uuid"
+	coapi "github.com/metal-toolbox/conditionorc/pkg/api/v1/types"
+	cotypes "github.com/metal-toolbox/conditionorc/pkg/types"
+	mctl "github.com/metal-toolbox/mctl/cmd"
+	"github.com/metal-toolbox/mctl/internal/app"
+	"github.com/spf13/cobra"
+)
+
+var serverIDStr string
+
+var installStatus = &cobra.Command{
+	Use:   "status --server | -s <server uuid>",
+	Short: "check the progress of a firmware install on a server",
+	Run: func(cmd *cobra.Command, _ []string) {
+		statusCheck(cmd.Context())
+	},
+}
+
+func statusCheck(ctx context.Context) {
+	theApp := mctl.MustCreateApp(ctx)
+
+	client, err := app.NewConditionsClient(ctx, theApp.Config.Conditions, theApp.Reauth)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	serverID, err := uuid.Parse(serverIDStr)
+	if err != nil {
+		log.Fatalf("parsing server id: %s", err.Error())
+	}
+
+	resp, err := client.ServerConditionGet(ctx, serverID, cotypes.FirmwareInstall)
+	if err != nil {
+		log.Fatalf("querying server conditions: %s", err.Error())
+	}
+
+	fmt.Println(formatCondition(resp))
+}
+
+type conditionDisplay struct {
+	ID         uuid.UUID              `json:"id"`
+	Kind       cotypes.ConditionKind  `json:"kind"`
+	State      cotypes.ConditionState `json:"state"`
+	Parameters json.RawMessage        `json:"parameters"`
+	Status     json.RawMessage        `json:"status"`
+}
+
+// XXX: this logs Fatal on errors, and I don't love it but the choice is boilerplate error
+// definitions and handling or do something expediant in a one-file command function.
+func formatCondition(resp *coapi.ServerResponse) string {
+	if resp.Records == nil {
+		log.Fatal("no records returned")
+	}
+
+	if len(resp.Records.Conditions) == 0 {
+		log.Fatal("no install condition found")
+	}
+
+	inc := resp.Records.Conditions[0]
+
+	display := &conditionDisplay{
+		ID:         inc.ID,
+		Kind:       inc.Kind,
+		Parameters: inc.Parameters,
+		State:      inc.State,
+		Status:     inc.Status,
+	}
+
+	// XXX: seems highly unlikely that we get a response that deserializes cleanly and doesn't
+	// re-serialize.
+	b, err := json.MarshalIndent(display, "", "  ")
+	if err != nil {
+		log.Fatalf("bad json in response: %s", err.Error())
+	}
+
+	return string(b)
+}
+
+func init() {
+	flags := installStatus.Flags()
+	flags.StringVarP(&serverIDStr, "server", "s", "", "server id (typically a UUID)")
+
+	if err := installStatus.MarkFlagRequired("server"); err != nil {
+		log.Fatalf("marking server flag as required: %s", err.Error())
+	}
+
+	install.AddCommand(installStatus)
+}

--- a/cmd/list/list.go
+++ b/cmd/list/list.go
@@ -13,6 +13,7 @@ var list = &cobra.Command{
 	Use:   "list",
 	Short: "List resources",
 	Run: func(cmd *cobra.Command, args []string) {
+		//nolint:errcheck // returns nil
 		cmd.Help()
 	},
 }

--- a/pkg/attributes/firmware.go
+++ b/pkg/attributes/firmware.go
@@ -12,20 +12,22 @@ var (
 )
 
 type firmwareAttribute struct {
-	Firmware *bmc.Firmware `json:"firmware",omitempty`
+	Firmware *bmc.Firmware `json:"firmware,omitempty"`
 }
 
 type ComponentWithFirmware struct {
 	Name     string        `json:"name"`
 	Vendor   string        `json:"vendor"`
 	Model    string        `json:"model"`
-	Firmware *bmc.Firmware `json:firmware`
+	Firmware *bmc.Firmware `json:"firmware"`
 }
 
 func FirmwareFromComponents(cs []ss.ServerComponent) []*ComponentWithFirmware {
 	var set []*ComponentWithFirmware
-	for _, c := range cs {
+	for idx := range cs {
+		c := cs[idx]
 		for _, attr := range c.VersionedAttributes {
+			attr := attr
 			if ok, fw := isFirmwareAttribute(&attr); ok {
 				set = append(set, &ComponentWithFirmware{
 					Name:     c.Name,


### PR DESCRIPTION
example output: 
`➜  mctl git:(vc/install-status) ./mctl --config ~/.mctl/hollow.yml install status --server ead994dc-40bb-42de-a404-6983f9abbb1b`
{
  "id": "827a6660-03e9-4082-8ba8-6de7b603a7e1",
  "kind": "firmwareInstall",
  "state": "succeeded",
  "parameters": {
    "assetID": "ead994dc-40bb-42de-a404-6983f9abbb1b",
    "firmwareSetID": "ce3a7a82-192b-427b-b965-6a58cb02c7de",
    "resetBMCBeforeInstall": true
  },
  "status": {
    "msg": "component: bios, completed firmware install, version: 2.8.5"
  }
}