### PR TITLE
Update fw-set edit commands to add/remove firmware from fw-sets

### DIFF
--- a/cmd/create/firmware_set.go
+++ b/cmd/create/firmware_set.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"strings"
 
 	"github.com/google/uuid"
 	mctl "github.com/metal-toolbox/mctl/cmd"
@@ -44,7 +43,7 @@ var createFirmwareSet = &cobra.Command{
 			payload.Attributes = []ss.Attributes{*attrs}
 		}
 
-		for _, id := range strings.Split(definedfirmwareSetFlags.AddFirmwareUUIDs, ",") {
+		for _, id := range definedfirmwareSetFlags.AddFirmwareUUIDs {
 			_, err = uuid.Parse(id)
 			if err != nil {
 				log.Println(err.Error())
@@ -70,7 +69,7 @@ var createFirmwareSet = &cobra.Command{
 func init() {
 	definedfirmwareSetFlags = &mctl.FirmwareSetFlags{}
 
-	createFirmwareSet.PersistentFlags().StringVar(&definedfirmwareSetFlags.AddFirmwareUUIDs, "firmware-uuids", "", "comma separated list of UUIDs of firmware to be included in the set to be created")
+	createFirmwareSet.PersistentFlags().StringSliceVar(&definedfirmwareSetFlags.AddFirmwareUUIDs, "firmware-uuids", []string{}, "comma separated list of UUIDs of firmware to be included in the set to be created")
 	createFirmwareSet.PersistentFlags().StringVar(&definedfirmwareSetFlags.FirmwareSetName, "name", "", "A name for the firmware set")
 	createFirmwareSet.PersistentFlags().StringToStringVar(&definedfirmwareSetFlags.Labels, "labels", nil, "Labels to assign to the firmware set - 'vendor=foo,model=bar'")
 

--- a/cmd/create/firmware_set.go
+++ b/cmd/create/firmware_set.go
@@ -3,7 +3,6 @@ package create
 import (
 	"fmt"
 	"log"
-	"os"
 
 	"github.com/google/uuid"
 	mctl "github.com/metal-toolbox/mctl/cmd"
@@ -46,8 +45,7 @@ var createFirmwareSet = &cobra.Command{
 		for _, id := range definedfirmwareSetFlags.AddFirmwareUUIDs {
 			_, err = uuid.Parse(id)
 			if err != nil {
-				log.Println(err.Error())
-				os.Exit(1)
+				log.Fatal(err)
 			}
 
 			payload.ComponentFirmwareUUIDs = append(payload.ComponentFirmwareUUIDs, id)

--- a/cmd/create/firmware_set.go
+++ b/cmd/create/firmware_set.go
@@ -44,7 +44,7 @@ var createFirmwareSet = &cobra.Command{
 			payload.Attributes = []ss.Attributes{*attrs}
 		}
 
-		for _, id := range strings.Split(definedfirmwareSetFlags.FirmwareUUIDs, ",") {
+		for _, id := range strings.Split(definedfirmwareSetFlags.AddFirmwareUUIDs, ",") {
 			_, err = uuid.Parse(id)
 			if err != nil {
 				log.Println(err.Error())
@@ -70,7 +70,7 @@ var createFirmwareSet = &cobra.Command{
 func init() {
 	definedfirmwareSetFlags = &mctl.FirmwareSetFlags{}
 
-	createFirmwareSet.PersistentFlags().StringVar(&definedfirmwareSetFlags.FirmwareUUIDs, "firmware-uuids", "", "comma separated list of UUIDs of firmware to be included in the set to be created")
+	createFirmwareSet.PersistentFlags().StringVar(&definedfirmwareSetFlags.AddFirmwareUUIDs, "firmware-uuids", "", "comma separated list of UUIDs of firmware to be included in the set to be created")
 	createFirmwareSet.PersistentFlags().StringVar(&definedfirmwareSetFlags.FirmwareSetName, "name", "", "A name for the firmware set")
 	createFirmwareSet.PersistentFlags().StringToStringVar(&definedfirmwareSetFlags.Labels, "labels", nil, "Labels to assign to the firmware set - 'vendor=foo,model=bar'")
 

--- a/cmd/edit/firmware_set.go
+++ b/cmd/edit/firmware_set.go
@@ -40,6 +40,8 @@ var editFirmwareSet = &cobra.Command{
 		}
 
 		var attrs *ss.Attributes
+		var payloadUpdated bool
+
 		if len(editFWSetFlags.Labels) > 0 {
 			attrs, err = mctl.AttributeFromLabels(model.AttributeNSFirmwareSetLabels, editFWSetFlags.Labels)
 			if err != nil {
@@ -47,15 +49,34 @@ var editFirmwareSet = &cobra.Command{
 			}
 
 			payload.Attributes = []ss.Attributes{*attrs}
+			payloadUpdated = true
 
+		}
+
+		if len(editFWSetFlags.AddFirmwareUUIDs) > 0 {
+			for _, id := range strings.Split(editFWSetFlags.AddFirmwareUUIDs, ",") {
+				_, err = uuid.Parse(id)
+				if err != nil {
+					log.Println(err.Error())
+					os.Exit(1)
+				}
+
+				payload.ComponentFirmwareUUIDs = append(payload.ComponentFirmwareUUIDs, id)
+				payloadUpdated = true
+			}
+		}
+
+
+		if payloadUpdated {
 			_, err = client.UpdateComponentFirmwareSetRequest(cmd.Context(), id, payload)
 			if err != nil {
 				log.Fatal(err)
 			}
+			fmt.Println("firmware set updated: " + id.String())
 		}
 
-		if len(editFWSetFlags.FirmwareUUIDs) > 0 {
-			for _, id := range strings.Split(editFWSetFlags.FirmwareUUIDs, ",") {
+		if len(editFWSetFlags.RemoveFirmwareUUIDs) > 0 {
+			for _, id := range strings.Split(editFWSetFlags.RemoveFirmwareUUIDs, ",") {
 				_, err = uuid.Parse(id)
 				if err != nil {
 					log.Println(err.Error())
@@ -69,9 +90,8 @@ var editFirmwareSet = &cobra.Command{
 			if err != nil {
 				log.Fatal(err)
 			}
+			fmt.Println("firmware set uuids removed: " + id.String())
 		}
-
-		fmt.Println("firmware set updated: " + id.String())
 	},
 }
 
@@ -85,6 +105,7 @@ func init() {
 		log.Fatal(err)
 	}
 
-	cmdFlags.StringVar(&editFWSetFlags.FirmwareUUIDs, "remove-firmware-uuids", "", "UUIDs of firmware to be removed from the set")
+	cmdFlags.StringVar(&editFWSetFlags.RemoveFirmwareUUIDs, "remove-firmware-uuids", "", "UUIDs of firmware to be removed from the set")
+	cmdFlags.StringVar(&editFWSetFlags.AddFirmwareUUIDs, "add-firmware-uuids", "", "UUIDs of firmware to be added to the set")
 
 }

--- a/cmd/edit/firmware_set.go
+++ b/cmd/edit/firmware_set.go
@@ -54,7 +54,7 @@ var editFirmwareSet = &cobra.Command{
 			}
 		}
 
-		if len(payload.ComponentFirmwareUUIDs) > 0 {
+		if len(editFWSetFlags.FirmwareUUIDs) > 0 {
 			for _, id := range strings.Split(editFWSetFlags.FirmwareUUIDs, ",") {
 				_, err = uuid.Parse(id)
 				if err != nil {

--- a/cmd/edit/firmware_set.go
+++ b/cmd/edit/firmware_set.go
@@ -57,7 +57,7 @@ var editFirmwareSet = &cobra.Command{
 			for _, id := range strings.Split(editFWSetFlags.AddFirmwareUUIDs, ",") {
 				_, err = uuid.Parse(id)
 				if err != nil {
-					log.Println(err.Error())
+					log.Fatal(err)
 					os.Exit(1)
 				}
 
@@ -83,7 +83,7 @@ var editFirmwareSet = &cobra.Command{
 			for _, id := range strings.Split(editFWSetFlags.RemoveFirmwareUUIDs, ",") {
 				_, err = uuid.Parse(id)
 				if err != nil {
-					log.Println(err.Error())
+					log.Fatal(err)
 					os.Exit(1)
 				}
 

--- a/cmd/edit/firmware_set.go
+++ b/cmd/edit/firmware_set.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"strings"
 
 	"github.com/google/uuid"
 	mctl "github.com/metal-toolbox/mctl/cmd"
@@ -54,7 +53,7 @@ var editFirmwareSet = &cobra.Command{
 		}
 
 		if len(editFWSetFlags.AddFirmwareUUIDs) > 0 {
-			for _, id := range strings.Split(editFWSetFlags.AddFirmwareUUIDs, ",") {
+			for _, id := range editFWSetFlags.AddFirmwareUUIDs {
 				_, err = uuid.Parse(id)
 				if err != nil {
 					log.Fatal(err)
@@ -80,7 +79,7 @@ var editFirmwareSet = &cobra.Command{
 		}
 
 		if len(editFWSetFlags.RemoveFirmwareUUIDs) > 0 {
-			for _, id := range strings.Split(editFWSetFlags.RemoveFirmwareUUIDs, ",") {
+			for _, id := range editFWSetFlags.RemoveFirmwareUUIDs {
 				_, err = uuid.Parse(id)
 				if err != nil {
 					log.Fatal(err)
@@ -109,7 +108,7 @@ func init() {
 		log.Fatal(err)
 	}
 
-	cmdFlags.StringVar(&editFWSetFlags.RemoveFirmwareUUIDs, "remove-firmware-uuids", "", "UUIDs of firmware to be removed from the set")
-	cmdFlags.StringVar(&editFWSetFlags.AddFirmwareUUIDs, "add-firmware-uuids", "", "UUIDs of firmware to be added to the set")
+	cmdFlags.StringSliceVar(&editFWSetFlags.RemoveFirmwareUUIDs, "remove-firmware-uuids", []string{}, "UUIDs of firmware to be removed from the set")
+	cmdFlags.StringSliceVar(&editFWSetFlags.AddFirmwareUUIDs, "add-firmware-uuids", []string{}, "UUIDs of firmware to be added to the set")
 
 }

--- a/cmd/edit/firmware_set.go
+++ b/cmd/edit/firmware_set.go
@@ -3,7 +3,6 @@ package edit
 import (
 	"fmt"
 	"log"
-	"os"
 
 	"github.com/google/uuid"
 	mctl "github.com/metal-toolbox/mctl/cmd"
@@ -57,7 +56,6 @@ var editFirmwareSet = &cobra.Command{
 				_, err = uuid.Parse(id)
 				if err != nil {
 					log.Fatal(err)
-					os.Exit(1)
 				}
 
 				payload.ComponentFirmwareUUIDs = append(payload.ComponentFirmwareUUIDs, id)
@@ -83,7 +81,6 @@ var editFirmwareSet = &cobra.Command{
 				_, err = uuid.Parse(id)
 				if err != nil {
 					log.Fatal(err)
-					os.Exit(1)
 				}
 
 				payload.ComponentFirmwareUUIDs = append(payload.ComponentFirmwareUUIDs, id)

--- a/cmd/edit/firmware_set.go
+++ b/cmd/edit/firmware_set.go
@@ -66,6 +66,10 @@ var editFirmwareSet = &cobra.Command{
 			}
 		}
 
+		if len(editFWSetFlags.FirmwareSetName) > 0 {
+			payload.Name = editFWSetFlags.FirmwareSetName
+			payloadUpdated = true
+		}
 
 		if payloadUpdated {
 			_, err = client.UpdateComponentFirmwareSetRequest(cmd.Context(), id, payload)

--- a/cmd/types.go
+++ b/cmd/types.go
@@ -6,8 +6,10 @@ type FirmwareSetFlags struct {
 	Labels map[string]string
 	// id is the firmware set id
 	ID string
-	// comma separated list of firmware UUIDs
-	FirmwareUUIDs string
+	// comma separated list of firmware UUIDs to be added to the set
+	AddFirmwareUUIDs string
+	// comma separated list of firmware UUIDs to be removed from the set
+	RemoveFirmwareUUIDs string
 	// name for the firmware set to be created/edited
 	FirmwareSetName string
 }

--- a/cmd/types.go
+++ b/cmd/types.go
@@ -6,10 +6,10 @@ type FirmwareSetFlags struct {
 	Labels map[string]string
 	// id is the firmware set id
 	ID string
-	// comma separated list of firmware UUIDs to be added to the set
-	AddFirmwareUUIDs string
-	// comma separated list of firmware UUIDs to be removed from the set
-	RemoveFirmwareUUIDs string
+	// list of firmware UUIDs to be added to the set
+	AddFirmwareUUIDs []string
+	// list of firmware UUIDs to be removed from the set
+	RemoveFirmwareUUIDs []string
 	// name for the firmware set to be created/edited
 	FirmwareSetName string
 }


### PR DESCRIPTION
Although originally ([d146f3d](https://github.com/metal-toolbox/mctl/pull/19/commits/d146f3db5f5812a2387342dd37d502bf27cf025e)) only fixed a no-op while removing fw from fw-sets, I made some further changes:
 - add firmware to existing sets
 - fix no-op for fw-set name update

Let me know if you prefer this as individual PRs or if it's fine as is.