### PR TITLE
Do not pollute home dir

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -45,6 +45,6 @@ func Execute() {
 }
 
 func init() {
-	RootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.mctl.yml)")
+	RootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $XDG_CONFIG_HOME/mctl/config.yml)")
 	RootCmd.PersistentFlags().BoolVar(&reAuth, "reauth", false, "re-authenticate with oauth services")
 }

--- a/docs/mctl.md
+++ b/docs/mctl.md
@@ -7,7 +7,7 @@ mctl is a CLI utility to interact with metal toolbox services
 ### Options
 
 ```
-      --config string   config file (default is $HOME/.mctl.yml)
+      --config string   config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
   -h, --help            help for mctl
       --reauth          re-authenticate with oauth services
 ```

--- a/docs/mctl_completion.md
+++ b/docs/mctl_completion.md
@@ -19,7 +19,7 @@ See each sub-command's help for details on how to use the generated script.
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.mctl.yml)
+      --config string   config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
       --reauth          re-authenticate with oauth services
 ```
 

--- a/docs/mctl_completion_bash.md
+++ b/docs/mctl_completion_bash.md
@@ -42,7 +42,7 @@ mctl completion bash
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.mctl.yml)
+      --config string   config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
       --reauth          re-authenticate with oauth services
 ```
 

--- a/docs/mctl_completion_fish.md
+++ b/docs/mctl_completion_fish.md
@@ -33,7 +33,7 @@ mctl completion fish [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.mctl.yml)
+      --config string   config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
       --reauth          re-authenticate with oauth services
 ```
 

--- a/docs/mctl_completion_powershell.md
+++ b/docs/mctl_completion_powershell.md
@@ -30,7 +30,7 @@ mctl completion powershell [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.mctl.yml)
+      --config string   config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
       --reauth          re-authenticate with oauth services
 ```
 

--- a/docs/mctl_completion_zsh.md
+++ b/docs/mctl_completion_zsh.md
@@ -44,7 +44,7 @@ mctl completion zsh [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.mctl.yml)
+      --config string   config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
       --reauth          re-authenticate with oauth services
 ```
 

--- a/docs/mctl_create.md
+++ b/docs/mctl_create.md
@@ -17,7 +17,7 @@ mctl create [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.mctl.yml)
+      --config string   config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
       --reauth          re-authenticate with oauth services
 ```
 

--- a/docs/mctl_create_firmware-set.md
+++ b/docs/mctl_create_firmware-set.md
@@ -20,7 +20,7 @@ mctl create firmware-set [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.mctl.yml)
+      --config string   config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
       --reauth          re-authenticate with oauth services
 ```
 

--- a/docs/mctl_create_firmware-set.md
+++ b/docs/mctl_create_firmware-set.md
@@ -11,10 +11,10 @@ mctl create firmware-set [flags]
 ### Options
 
 ```
-      --firmware-uuids string   comma separated list of UUIDs of firmware to be included in the set to be created
-  -h, --help                    help for firmware-set
-      --labels stringToString   Labels to assign to the firmware set - 'vendor=foo,model=bar' (default [])
-      --name string             A name for the firmware set
+      --firmware-uuids strings   comma separated list of UUIDs of firmware to be included in the set to be created
+  -h, --help                     help for firmware-set
+      --labels stringToString    Labels to assign to the firmware set - 'vendor=foo,model=bar' (default [])
+      --name string              A name for the firmware set
 ```
 
 ### Options inherited from parent commands

--- a/docs/mctl_create_firmware.md
+++ b/docs/mctl_create_firmware.md
@@ -11,7 +11,7 @@ mctl create firmware [flags]
 ### Options
 
 ```
-      --from-file string   YAML file with firmware configuration data
+      --from-file string   JSON file with firmware configuration data
   -h, --help               help for firmware
 ```
 

--- a/docs/mctl_create_firmware.md
+++ b/docs/mctl_create_firmware.md
@@ -18,7 +18,7 @@ mctl create firmware [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.mctl.yml)
+      --config string   config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
       --reauth          re-authenticate with oauth services
 ```
 

--- a/docs/mctl_delete.md
+++ b/docs/mctl_delete.md
@@ -17,7 +17,7 @@ mctl delete [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.mctl.yml)
+      --config string   config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
       --reauth          re-authenticate with oauth services
 ```
 

--- a/docs/mctl_delete_condition.md
+++ b/docs/mctl_delete_condition.md
@@ -19,7 +19,7 @@ mctl delete condition [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.mctl.yml)
+      --config string   config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
       --reauth          re-authenticate with oauth services
 ```
 

--- a/docs/mctl_delete_firmware-set.md
+++ b/docs/mctl_delete_firmware-set.md
@@ -18,7 +18,7 @@ mctl delete firmware-set [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.mctl.yml)
+      --config string   config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
       --reauth          re-authenticate with oauth services
 ```
 

--- a/docs/mctl_edit.md
+++ b/docs/mctl_edit.md
@@ -17,7 +17,7 @@ mctl edit [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.mctl.yml)
+      --config string   config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
       --reauth          re-authenticate with oauth services
 ```
 

--- a/docs/mctl_edit_firmware-set.md
+++ b/docs/mctl_edit_firmware-set.md
@@ -11,11 +11,12 @@ mctl edit firmware-set [flags]
 ### Options
 
 ```
-  -h, --help                           help for firmware-set
-      --labels stringToString          Labels to assign to the firmware set - 'vendor=foo,model=bar' (default [])
-      --name string                    Update name for the firmware set
-      --remove-firmware-uuids string   UUIDs of firmware to be removed from the set
-      --uuid string                    UUID of firmware set to be edited
+      --add-firmware-uuids strings      UUIDs of firmware to be added to the set
+  -h, --help                            help for firmware-set
+      --labels stringToString           Labels to assign to the firmware set - 'vendor=foo,model=bar' (default [])
+      --name string                     Update name for the firmware set
+      --remove-firmware-uuids strings   UUIDs of firmware to be removed from the set
+      --uuid string                     UUID of firmware set to be edited
 ```
 
 ### Options inherited from parent commands

--- a/docs/mctl_edit_firmware-set.md
+++ b/docs/mctl_edit_firmware-set.md
@@ -22,7 +22,7 @@ mctl edit firmware-set [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.mctl.yml)
+      --config string   config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
       --reauth          re-authenticate with oauth services
 ```
 

--- a/docs/mctl_gendocs.md
+++ b/docs/mctl_gendocs.md
@@ -17,7 +17,7 @@ mctl gendocs [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.mctl.yml)
+      --config string   config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
       --reauth          re-authenticate with oauth services
 ```
 

--- a/docs/mctl_get.md
+++ b/docs/mctl_get.md
@@ -18,7 +18,7 @@ mctl get [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.mctl.yml)
+      --config string   config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
       --reauth          re-authenticate with oauth services
 ```
 

--- a/docs/mctl_get_bios-config.md
+++ b/docs/mctl_get_bios-config.md
@@ -18,7 +18,7 @@ mctl get bios-config [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.mctl.yml)
+      --config string   config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
   -o, --output string   {json|text} (default "json")
       --reauth          re-authenticate with oauth services
 ```

--- a/docs/mctl_get_component.md
+++ b/docs/mctl_get_component.md
@@ -19,7 +19,7 @@ mctl get component [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.mctl.yml)
+      --config string   config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
   -o, --output string   {json|text} (default "json")
       --reauth          re-authenticate with oauth services
 ```

--- a/docs/mctl_get_condition.md
+++ b/docs/mctl_get_condition.md
@@ -19,7 +19,7 @@ mctl get condition [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.mctl.yml)
+      --config string   config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
   -o, --output string   {json|text} (default "json")
       --reauth          re-authenticate with oauth services
 ```

--- a/docs/mctl_get_firmware-set.md
+++ b/docs/mctl_get_firmware-set.md
@@ -19,7 +19,7 @@ mctl get firmware-set [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.mctl.yml)
+      --config string   config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
   -o, --output string   {json|text} (default "json")
       --reauth          re-authenticate with oauth services
 ```

--- a/docs/mctl_get_firmware.md
+++ b/docs/mctl_get_firmware.md
@@ -18,7 +18,7 @@ mctl get firmware [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.mctl.yml)
+      --config string   config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
   -o, --output string   {json|text} (default "json")
       --reauth          re-authenticate with oauth services
 ```

--- a/docs/mctl_install.md
+++ b/docs/mctl_install.md
@@ -17,7 +17,7 @@ mctl install [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.mctl.yml)
+      --config string   config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
       --reauth          re-authenticate with oauth services
 ```
 

--- a/docs/mctl_install_firmware-set.md
+++ b/docs/mctl_install_firmware-set.md
@@ -21,7 +21,7 @@ mctl install firmware-set [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.mctl.yml)
+      --config string   config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
       --reauth          re-authenticate with oauth services
 ```
 

--- a/docs/mctl_install_status.md
+++ b/docs/mctl_install_status.md
@@ -18,7 +18,7 @@ mctl install status --server | -s <server uuid> [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.mctl.yml)
+      --config string   config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
       --reauth          re-authenticate with oauth services
 ```
 

--- a/docs/mctl_list.md
+++ b/docs/mctl_list.md
@@ -18,7 +18,7 @@ mctl list [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.mctl.yml)
+      --config string   config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
       --reauth          re-authenticate with oauth services
 ```
 

--- a/docs/mctl_list_condition.md
+++ b/docs/mctl_list_condition.md
@@ -19,7 +19,7 @@ mctl list condition [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.mctl.yml)
+      --config string   config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
       --output-json     Output listing as JSON
       --reauth          re-authenticate with oauth services
 ```

--- a/docs/mctl_list_firmware-set.md
+++ b/docs/mctl_list_firmware-set.md
@@ -20,7 +20,7 @@ mctl list firmware-set [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.mctl.yml)
+      --config string   config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
       --output-json     Output listing as JSON
       --reauth          re-authenticate with oauth services
 ```

--- a/docs/mctl_list_firmware-set.md
+++ b/docs/mctl_list_firmware-set.md
@@ -11,6 +11,7 @@ mctl list firmware-set [flags]
 ### Options
 
 ```
+      --all             show all firmware sets. By default results are filtered on having labels for vendor, model and latest=true
   -h, --help            help for firmware-set
       --model string    filter by server model
       --vendor string   filter by server vendor

--- a/docs/mctl_list_firmware.md
+++ b/docs/mctl_list_firmware.md
@@ -17,7 +17,7 @@ mctl list firmware [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.mctl.yml)
+      --config string   config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
       --output-json     Output listing as JSON
       --reauth          re-authenticate with oauth services
 ```

--- a/docs/mctl_version.md
+++ b/docs/mctl_version.md
@@ -17,7 +17,7 @@ mctl version [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.mctl.yml)
+      --config string   config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
       --reauth          re-authenticate with oauth services
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/metal-toolbox/mctl
 go 1.19
 
 require (
+	github.com/adrg/xdg v0.4.0
 	github.com/bmc-toolbox/common v0.0.0-20230220061748-93ff001f4a1d
 	github.com/coreos/go-oidc v2.2.1+incompatible
 	github.com/davecgh/go-spew v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -509,6 +509,8 @@ github.com/Shopify/logrus-bugsnag v0.0.0-20171204204709-577dee27f20d/go.mod h1:H
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
 github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=
+github.com/adrg/xdg v0.4.0 h1:RzRqFcjH4nE5C6oTAxhBtoE2IRyjBSa62SCbyPidvls=
+github.com/adrg/xdg v0.4.0/go.mod h1:N6ag73EX4wyxeaoeHctc1mas01KZgsj5tYiAIwqJE/E=
 github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5/go.mod h1:SkGFH1ia65gfNATL8TAiHDNxPzPdmEL5uirI2Uyuz6c=
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -48,6 +48,19 @@ func openConfig(path string) (*os.File, error) {
 	}
 
 	path = filepath.Join(xdg.Home, ".mctl.yml")
+	f, err := os.Open(path)
+	if err != nil {
+		return f, nil
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		return nil, err
+	}
+
+	path, err = xdg.ConfigFile("mctl/config.yaml")
+	if err != nil {
+		return nil, err
+	}
+
 	return os.Open(path)
 }
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"net/url"
 	"os"
+	"path/filepath"
 
+	"github.com/adrg/xdg"
 	"github.com/metal-toolbox/mctl/pkg/model"
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
@@ -36,30 +38,28 @@ func New(_ context.Context, cfgFile string, reauth bool) (app *App, err error) {
 	return &App{Config: cfg, Reauth: reauth}, nil
 }
 
+func openConfig(path string) (*os.File, error) {
+	if path != "" {
+		return os.Open(path)
+	}
+	path = viper.GetString("mctlconfig")
+	if path != "" {
+		return os.Open(path)
+	}
+
+	path = filepath.Join(xdg.Home, ".mctl.yml")
+	return os.Open(path)
+}
+
 func loadConfig(cfgFile string) (*model.Config, error) {
 	cfg := &model.Config{}
-
-	if cfgFile != "" {
-		cfg.File = cfgFile
-	} else {
-		homedir, err := os.UserHomeDir()
-		if err != nil {
-			return nil, err
-		}
-
-		cfg.File = homedir + "/" + ".mctl.yml"
-	}
-
 	viper.AutomaticEnv()
-	if viper.GetString("mctlconfig") != "" {
-		cfg.File = viper.GetString("mctlconfig")
-	}
-
-	h, err := os.Open(cfg.File)
+	h, err := openConfig(cfgFile)
 	if err != nil {
 		return nil, err
 	}
 
+	cfg.File = h.Name()
 	viper.SetConfigFile(cfg.File)
 
 	err = viper.ReadConfig(h)


### PR DESCRIPTION
Lets be good cli folks and not pollute a user's $HOME, instead lets put config files in platform specified config paths. ~/.mctl.yml is used if it exists otherwise we look in dirs provided by xdg package.