### PR TITLE
Fix nil pointer error opening config file

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -49,7 +49,7 @@ func openConfig(path string) (*os.File, error) {
 
 	path = filepath.Join(xdg.Home, ".mctl.yml")
 	f, err := os.Open(path)
-	if err != nil {
+	if err == nil {
 		return f, nil
 	}
 	if !errors.Is(err, os.ErrNotExist) {


### PR DESCRIPTION
In case the config file exists in the home dir, use that one and return early, otherwise try to use the config file in
xdg.ConfigFile("mctl/config.yaml")

Fixes the following error: 
```$ ./mctl list firmware-set
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x18beaa9]

goroutine 1 [running]:
os.(*File).Name(...)
        /opt/hostedtoolcache/go/1.20.7/x64/src/os/file.go:56
github.com/metal-toolbox/mctl/internal/app.loadConfig({0x0, 0x0})
        /home/runner/work/mctl/mctl/internal/app/app.go:75 +0x69
github.com/metal-toolbox/mctl/internal/app.New({0x0?, 0x0?}, {0x0?, 0x0?}, 0x0)
        /home/runner/work/mctl/mctl/internal/app/app.go:28 +0x2d
github.com/metal-toolbox/mctl/cmd.MustCreateApp({0x1c485f0?, 0xc0001aa018?})
        /home/runner/work/mctl/mctl/cmd/common.go:33 +0x38
github.com/metal-toolbox/mctl/cmd/list.glob..func3(0x2240bc0, {0x1ab9f02?, 0x0?, 0x0?})
        /home/runner/work/mctl/mctl/cmd/list/firmware_set.go:32 +0x47
github.com/spf13/cobra.(*Command).execute(0x2240bc0, {0x2284ec8, 0x0, 0x0})
        /home/runner/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:944 +0x847
github.com/spf13/cobra.(*Command).ExecuteC(0x223cc80)
        /home/runner/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:1068 +0x3bd
github.com/spf13/cobra.(*Command).Execute(...)
        /home/runner/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:992
github.com/metal-toolbox/mctl/cmd.Execute()
        /home/runner/work/mctl/mctl/cmd/root.go:41 +0x25
main.main()
        /home/runner/work/mctl/mctl/main.go:30 +0x17
```