### PR TITLE
Check error in call to FormatConditionResponse()

### DIFF
--- a/cmd/install/status.go
+++ b/cmd/install/status.go
@@ -41,7 +41,12 @@ func statusCheck(ctx context.Context) {
 		log.Fatalf("querying server conditions: %s", err.Error())
 	}
 
-	fmt.Println(mctl.FormatConditionResponse(resp))
+	s, err := mctl.FormatConditionResponse(resp)
+	if err != nil {
+		log.Fatalf("error formating condition response: %s", err.Error())
+	}
+
+	fmt.Println(s)
 }
 
 func init() {


### PR DESCRIPTION
In case there are no errors, we print only the formatted response and not both the formatted string and nil