### PR TITLE
Fix firmware listing using the model filter

### DIFF
--- a/cmd/list/firmware.go
+++ b/cmd/list/firmware.go
@@ -16,7 +16,7 @@ import (
 type listFirmwareFlags struct {
 	server    string // server UUID
 	vendor    string
-	model     []string
+	models    []string
 	component string
 	version   string
 }
@@ -40,9 +40,18 @@ var listFirmware = &cobra.Command{
 			log.Fatal(err)
 		}
 
+		lowerCasedModels := func(models []string) []string {
+			lowered := []string{}
+			for _, m := range models {
+				lowered = append(lowered, strings.ToLower(m))
+			}
+
+			return lowered
+		}
+
 		filterParams := serverservice.ComponentFirmwareVersionListParams{
-			Vendor:  flagsDefinedListFirmware.vendor,
-			Model:   flagsDefinedListFirmware.model,
+			Vendor:  strings.ToLower(flagsDefinedListFirmware.vendor),
+			Model:   lowerCasedModels(flagsDefinedListFirmware.models),
 			Version: flagsDefinedListFirmware.version,
 		}
 
@@ -82,7 +91,7 @@ func init() {
 
 	listFirmware.PersistentFlags().StringVar(&flagsDefinedListFirmware.server, "server", "", "server UUID")
 	listFirmware.PersistentFlags().StringVar(&flagsDefinedListFirmware.vendor, "vendor", "", "vendor name")
-	listFirmware.PersistentFlags().StringSliceVar(&flagsDefinedListFirmware.model, "model", nil, "list of models separated by commas")
+	listFirmware.PersistentFlags().StringSliceVar(&flagsDefinedListFirmware.models, "models", nil, "one or more comma separated models numbers")
 	listFirmware.PersistentFlags().StringVar(&flagsDefinedListFirmware.component, "component", "", "component type")
 	listFirmware.PersistentFlags().StringVar(&flagsDefinedListFirmware.version, "version", "", "version number")
 }

--- a/docs/mctl_list_firmware.md
+++ b/docs/mctl_list_firmware.md
@@ -13,7 +13,7 @@ mctl list firmware [flags]
 ```
       --component string   component type
   -h, --help               help for firmware
-      --model strings      list of models separated by commas
+      --models strings     one or more comma separated models numbers
       --server string      server UUID
       --vendor string      vendor name
       --version string     version number


### PR DESCRIPTION
before 
```
❯ ./mctl list firmware --vendor supermicro --model X12STH-SYS                                                                                                                           
+------+--------+-------+-----------+---------+                                             
| UUID | VENDOR | MODEL | COMPONENT | VERSION |                                                                                                                                         
+------+--------+-------+-----------+---------+                                             
+------+--------+-------+-----------+---------+                                             
```

after
```
❯ ./mctl list firmware --vendor supermicro --models X12STH-SYS                                                                                                                           
+--------------------------------------+------------+------------+-----------+---------+                                                                                                
|                 UUID                 |   VENDOR   |   MODEL    | COMPONENT | VERSION |                                                                                                
+--------------------------------------+------------+------------+-----------+---------+                                                                                                
| 33c4ef45-e422-441a-92ce-e7a4df192aa2 | supermicro | x12sth-sys | bios      | 1.4a    |                                                                                                
| 8280d503-597d-4e7e-a34a-853367595c02 | supermicro | x12sth-sys | bios      |     1.2 |                                                                                                
| 82e1613a-0f21-465a-8f00-afe1778a25e5 | supermicro | x12sth-sys | bmc       | 1.13.04 |                                                                                                
| a05c9279-41b6-4a9a-8f8b-d66088927df8 | supermicro | x12sth-sys | bmc       | 0.13.19 |                                                                                                
| b9edada1-4619-40b8-a5e2-38a61afe9cfb | supermicro | x12sth-sys | bios      | 1.0a    |                                                                                                
| f6c2d98b-d804-4754-b8a8-7bb2016d85b7 | supermicro | x12sth-sys | bios      |     1.6 |                                                                                                
+--------------------------------------+------------+------------+-----------+---------+        
```