### PR TITLE
FS-1254 Standardize CLI flags

### DIFF
--- a/cmd/collect/collect.go
+++ b/cmd/collect/collect.go
@@ -1,30 +1,21 @@
 package collect
 
 import (
-	"log"
+	"github.com/spf13/cobra"
 
 	"github.com/metal-toolbox/mctl/cmd"
-	"github.com/spf13/cobra"
 )
-
-var serverIDStr string
 
 var collect = &cobra.Command{
 	Use:   "collect",
 	Short: "Collect current server firmware status and bios configuration",
 	Run: func(cmd *cobra.Command, args []string) {
-		//nolint:errcheck // returns nil
-		cmd.Help()
+		_ = cmd.Help()
 	},
 }
 
 func init() {
 	cmd.RootCmd.AddCommand(collect)
-
-	pflags := collect.PersistentFlags()
-	pflags.StringVarP(&serverIDStr, "server", "s", "", "server id (typically a UUID)")
-
-	if err := collect.MarkPersistentFlagRequired("server"); err != nil {
-		log.Fatalf("marking server flag as required: %s", err.Error())
-	}
+	collect.AddCommand(collectInventoryCmd)
+	collect.AddCommand(inventoryStatus)
 }

--- a/cmd/collect/inventory.go
+++ b/cmd/collect/inventory.go
@@ -8,14 +8,15 @@ import (
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 
-	"github.com/metal-toolbox/mctl/internal/app"
-
 	coapiv1 "github.com/metal-toolbox/conditionorc/pkg/api/v1/types"
-	mctl "github.com/metal-toolbox/mctl/cmd"
 	rctypes "github.com/metal-toolbox/rivets/condition"
+
+	mctl "github.com/metal-toolbox/mctl/cmd"
+	"github.com/metal-toolbox/mctl/internal/app"
 )
 
 type collectInventoryFlags struct {
+	serverID                  string
 	skipFirmwareStatusCollect bool
 	skipBiosConfigCollect     bool
 }
@@ -25,7 +26,7 @@ var (
 )
 
 var collectInventoryCmd = &cobra.Command{
-	Use:   "inventory --server | -s <server uuid>",
+	Use:   "inventory",
 	Short: "Collect current server firmware status and bios configuration",
 	Run: func(cmd *cobra.Command, _ []string) {
 		collectInventory(cmd.Context())
@@ -36,7 +37,7 @@ var collectInventoryCmd = &cobra.Command{
 func collectInventory(ctx context.Context) {
 	theApp := mctl.MustCreateApp(ctx)
 
-	serverID, err := uuid.Parse(serverIDStr)
+	serverID, err := uuid.Parse(flagsDefinedCollectInventory.serverID)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -77,9 +78,9 @@ func collectInventory(ctx context.Context) {
 func init() {
 	flagsDefinedCollectInventory = &collectInventoryFlags{}
 
-	collect.AddCommand(collectInventoryCmd)
-	collectInventoryCmd.PersistentFlags().BoolVar(&flagsDefinedCollectInventory.skipFirmwareStatusCollect,
-		"skip-fw-status", false, "Skip firmware status data collection")
-	collectInventoryCmd.PersistentFlags().BoolVar(&flagsDefinedCollectInventory.skipBiosConfigCollect,
-		"skip-bios-config", false, "Skip BIOS configuration data collection")
+	mctl.AddServerFlag(collectInventoryCmd, &flagsDefinedCollectInventory.serverID)
+	mctl.AddSkipFWStatusFlag(collectInventoryCmd, &flagsDefinedCollectInventory.skipFirmwareStatusCollect)
+	mctl.AddSkipBiosConfigFlag(collectInventoryCmd, &flagsDefinedCollectInventory.skipBiosConfigCollect)
+
+	mctl.RequireFlag(collectInventoryCmd, mctl.ServerFlag)
 }

--- a/cmd/collect/status.go
+++ b/cmd/collect/status.go
@@ -6,16 +6,22 @@ import (
 	"log"
 
 	"github.com/google/uuid"
-
-	"github.com/metal-toolbox/mctl/internal/app"
 	"github.com/spf13/cobra"
 
-	mctl "github.com/metal-toolbox/mctl/cmd"
 	rctypes "github.com/metal-toolbox/rivets/condition"
+
+	mctl "github.com/metal-toolbox/mctl/cmd"
+	"github.com/metal-toolbox/mctl/internal/app"
 )
 
+type inventoryStatusParams struct {
+	serverID string
+}
+
+var inventoryStatusFlags *inventoryStatusParams
+
 var inventoryStatus = &cobra.Command{
-	Use:   "status --server | -s <server uuid>",
+	Use:   "status",
 	Short: "check the progress of a inventory collection for a server",
 	Run: func(cmd *cobra.Command, _ []string) {
 		statusCheck(cmd.Context())
@@ -30,7 +36,7 @@ func statusCheck(ctx context.Context) {
 		log.Fatal(err)
 	}
 
-	serverID, err := uuid.Parse(serverIDStr)
+	serverID, err := uuid.Parse(inventoryStatusFlags.serverID)
 	if err != nil {
 		log.Fatalf("parsing server id: %s", err.Error())
 	}
@@ -49,5 +55,8 @@ func statusCheck(ctx context.Context) {
 }
 
 func init() {
-	collect.AddCommand(inventoryStatus)
+	inventoryStatusFlags = &inventoryStatusParams{}
+
+	mctl.AddServerFlag(inventoryStatus, &inventoryStatusFlags.serverID)
+	mctl.RequireFlag(inventoryStatus, mctl.ServerFlag)
 }

--- a/cmd/create/bomupload.go
+++ b/cmd/create/bomupload.go
@@ -4,9 +4,10 @@ import (
 	"log"
 	"os"
 
+	"github.com/spf13/cobra"
+
 	mctl "github.com/metal-toolbox/mctl/cmd"
 	"github.com/metal-toolbox/mctl/internal/app"
-	"github.com/spf13/cobra"
 )
 
 // Create Bom informations.
@@ -46,11 +47,8 @@ var uploadBomFile = &cobra.Command{
 
 func init() {
 	flagsUploadBomFileFlags = &uploadBomFileFlags{}
+	usage := "xlsx file with BOM information"
 
-	uploadBomFile.PersistentFlags().StringVar(
-		&flagsUploadBomFileFlags.bomXlsxFile,
-		"from-xlsx-file", "", "Xlsx file with bom informations")
-	if err := uploadBomFile.MarkPersistentFlagRequired("from-xlsx-file"); err != nil {
-		log.Fatal(err)
-	}
+	mctl.AddFromFileFlag(uploadBomFile, &flagsUploadBomFileFlags.bomXlsxFile, usage)
+	mctl.RequireFlag(uploadBomFile, mctl.FromFileFlag)
 }

--- a/cmd/create/firmware.go
+++ b/cmd/create/firmware.go
@@ -5,10 +5,11 @@ import (
 	"log"
 	"os"
 
-	mctl "github.com/metal-toolbox/mctl/cmd"
-	"github.com/metal-toolbox/mctl/internal/app"
 	"github.com/spf13/cobra"
 	serverservice "go.hollow.sh/serverservice/pkg/api/v1"
+
+	mctl "github.com/metal-toolbox/mctl/cmd"
+	"github.com/metal-toolbox/mctl/internal/app"
 )
 
 // Create
@@ -55,11 +56,8 @@ var createFirmware = &cobra.Command{
 
 func init() {
 	flagsDefinedCreateFirmware = &createFirmwareFlags{}
+	usage := "JSON file with firmware configuration data"
 
-	createFirmware.PersistentFlags().StringVar(
-		&flagsDefinedCreateFirmware.firmwareConfigFile,
-		"from-file", "", "JSON file with firmware configuration data")
-	if err := createFirmware.MarkPersistentFlagRequired("from-file"); err != nil {
-		log.Fatal(err)
-	}
+	mctl.AddFromFileFlag(createFirmware, &flagsDefinedCreateFirmware.firmwareConfigFile, usage)
+	mctl.RequireFlag(createFirmware, mctl.FromFileFlag)
 }

--- a/cmd/create/firmware_set.go
+++ b/cmd/create/firmware_set.go
@@ -5,11 +5,12 @@ import (
 	"log"
 
 	"github.com/google/uuid"
+	"github.com/spf13/cobra"
+	ss "go.hollow.sh/serverservice/pkg/api/v1"
+
 	mctl "github.com/metal-toolbox/mctl/cmd"
 	"github.com/metal-toolbox/mctl/internal/app"
 	"github.com/metal-toolbox/mctl/pkg/model"
-	"github.com/spf13/cobra"
-	ss "go.hollow.sh/serverservice/pkg/api/v1"
 )
 
 var (
@@ -67,17 +68,11 @@ var createFirmwareSet = &cobra.Command{
 func init() {
 	definedfirmwareSetFlags = &mctl.FirmwareSetFlags{}
 
-	createFirmwareSet.PersistentFlags().StringSliceVar(&definedfirmwareSetFlags.AddFirmwareUUIDs, "firmware-uuids", []string{}, "comma separated list of UUIDs of firmware to be included in the set to be created")
-	createFirmwareSet.PersistentFlags().StringVar(&definedfirmwareSetFlags.FirmwareSetName, "name", "", "A name for the firmware set")
-	createFirmwareSet.PersistentFlags().StringToStringVar(&definedfirmwareSetFlags.Labels, "labels", nil, "Labels to assign to the firmware set - 'vendor=foo,model=bar'")
+	mctl.AddFirmwareIDsFlag(createFirmwareSet, &definedfirmwareSetFlags.AddFirmwareUUIDs)
+	mctl.AddNameFlag(createFirmwareSet, &definedfirmwareSetFlags.FirmwareSetName, "A name for the firmware set")
+	mctl.AddLabelsFlag(createFirmwareSet, &definedfirmwareSetFlags.Labels,
+		"Labels to assign to the firmware set - 'vendor=foo,model=bar'")
 
-	// mark flags as required
-	if err := createFirmwareSet.MarkPersistentFlagRequired("firmware-uuids"); err != nil {
-		log.Fatal(err)
-	}
-
-	if err := createFirmwareSet.MarkPersistentFlagRequired("name"); err != nil {
-		log.Fatal(err)
-	}
-
+	mctl.RequireFlag(createFirmwareSet, mctl.FirmwareIDsFlag)
+	mctl.RequireFlag(createFirmwareSet, mctl.NameFlag)
 }

--- a/cmd/create/server.go
+++ b/cmd/create/server.go
@@ -5,12 +5,11 @@ import (
 	"encoding/json"
 	"log"
 
+	coapiv1 "github.com/metal-toolbox/conditionorc/pkg/api/v1/types"
 	"github.com/spf13/cobra"
 
-	"github.com/metal-toolbox/mctl/internal/app"
-
-	coapiv1 "github.com/metal-toolbox/conditionorc/pkg/api/v1/types"
 	mctl "github.com/metal-toolbox/mctl/cmd"
+	"github.com/metal-toolbox/mctl/internal/app"
 )
 
 type serverEnrollParams struct {
@@ -72,25 +71,14 @@ func enrollServer(ctx context.Context) {
 func init() {
 	serverEnrollFlags = &serverEnrollParams{}
 
-	serverEnroll.PersistentFlags().StringVar(&serverEnrollFlags.serverID, "server-id", "", "server id to be created. New id will be created if null.")
-	serverEnroll.PersistentFlags().StringVar(&serverEnrollFlags.facility, "facility", "", "facility of the server")
-	serverEnroll.PersistentFlags().StringVar(&serverEnrollFlags.ip, "ip", "", "ip of the server")
-	serverEnroll.PersistentFlags().StringVar(&serverEnrollFlags.username, "user", "", "username of the server")
-	serverEnroll.PersistentFlags().StringVar(&serverEnrollFlags.password, "pwd", "", "password of the server")
+	mctl.AddAddressFlag(serverEnroll, &serverEnrollFlags.ip)
+	mctl.AddUsernameFlag(serverEnroll, &serverEnrollFlags.username)
+	mctl.AddPasswordFlag(serverEnroll, &serverEnrollFlags.password)
+	mctl.AddFacilityFlag(serverEnroll, &serverEnrollFlags.facility)
+	mctl.AddServerFlag(serverEnroll, &serverEnrollFlags.serverID)
 
-	if err := serverEnroll.MarkPersistentFlagRequired("facility"); err != nil {
-		log.Fatal(err)
-	}
-
-	if err := serverEnroll.MarkPersistentFlagRequired("ip"); err != nil {
-		log.Fatal(err)
-	}
-
-	if err := serverEnroll.MarkPersistentFlagRequired("user"); err != nil {
-		log.Fatal(err)
-	}
-
-	if err := serverEnroll.MarkPersistentFlagRequired("pwd"); err != nil {
-		log.Fatal(err)
-	}
+	mctl.RequireFlag(serverEnroll, mctl.AddressFlag)
+	mctl.RequireFlag(serverEnroll, mctl.UsernameFlag)
+	mctl.RequireFlag(serverEnroll, mctl.PasswordFlag)
+	mctl.RequireFlag(serverEnroll, mctl.FacilityFlag)
 }

--- a/cmd/delete/delete.go
+++ b/cmd/delete/delete.go
@@ -10,8 +10,7 @@ var deleteCmd = &cobra.Command{
 	Use:   "delete",
 	Short: "Delete resources",
 	Run: func(cmd *cobra.Command, args []string) {
-		//nolint:errcheck // returns nil
-		cmd.Help()
+		_ = cmd.Help()
 	},
 }
 

--- a/cmd/delete/firmware.go
+++ b/cmd/delete/firmware.go
@@ -5,10 +5,11 @@ import (
 	"log"
 
 	"github.com/google/uuid"
-	mctl "github.com/metal-toolbox/mctl/cmd"
-	"github.com/metal-toolbox/mctl/internal/app"
 	"github.com/spf13/cobra"
 	serverservice "go.hollow.sh/serverservice/pkg/api/v1"
+
+	mctl "github.com/metal-toolbox/mctl/cmd"
+	"github.com/metal-toolbox/mctl/internal/app"
 )
 
 type deleteFirmwareFlags struct {
@@ -47,9 +48,6 @@ var deleteFirmware = &cobra.Command{
 func init() {
 	flagsDefinedDeleteFirmware = &deleteFirmwareFlags{}
 
-	deleteFirmware.PersistentFlags().StringVarP(&flagsDefinedDeleteFirmware.id, "firmware-id", "f", "", "UUID of firmware object to be deleted")
-
-	if err := deleteFirmware.MarkPersistentFlagRequired("firmware-id"); err != nil {
-		log.Fatal(err)
-	}
+	mctl.AddFirmwareFlag(deleteFirmware, &flagsDefinedDeleteFirmware.id)
+	mctl.RequireFlag(deleteFirmware, mctl.FirmwareFlag)
 }

--- a/cmd/delete/firmware_set.go
+++ b/cmd/delete/firmware_set.go
@@ -5,9 +5,10 @@ import (
 	"log"
 
 	"github.com/google/uuid"
+	"github.com/spf13/cobra"
+
 	mctl "github.com/metal-toolbox/mctl/cmd"
 	"github.com/metal-toolbox/mctl/internal/app"
-	"github.com/spf13/cobra"
 )
 
 var (
@@ -40,9 +41,6 @@ var deleteFirmwareSet = &cobra.Command{
 }
 
 func init() {
-	deleteFirmwareSet.PersistentFlags().StringVar(&deleteFWSetFlags.ID, "uuid", "", "UUID of firmware set to be deleted")
-
-	if err := deleteFirmwareSet.MarkPersistentFlagRequired("uuid"); err != nil {
-		log.Fatal(err)
-	}
+	mctl.AddFirmwareSetFlag(deleteFirmwareSet, &deleteFWSetFlags.ID)
+	mctl.RequireFlag(deleteFirmwareSet, mctl.FirmwareSetFlag)
 }

--- a/cmd/delete/serverdelete.go
+++ b/cmd/delete/serverdelete.go
@@ -46,9 +46,6 @@ func deleteServer(ctx context.Context) {
 func init() {
 	serverDeleteFlags = &serverDeleteParams{}
 
-	serverDelete.PersistentFlags().StringVar(&serverDeleteFlags.serverID, "server-id", "", "server id to be deleted")
-
-	if err := serverDelete.MarkPersistentFlagRequired("server-id"); err != nil {
-		log.Fatal(err)
-	}
+	mctl.AddServerFlag(serverDelete, &serverDeleteFlags.serverID)
+	mctl.RequireFlag(serverDelete, mctl.ServerFlag)
 }

--- a/cmd/edit/edit.go
+++ b/cmd/edit/edit.go
@@ -10,8 +10,7 @@ var edit = &cobra.Command{
 	Use:   "edit",
 	Short: "Edit resources",
 	Run: func(cmd *cobra.Command, args []string) {
-		//nolint:errcheck // returns nil
-		cmd.Help()
+		_ = cmd.Help()
 	},
 }
 

--- a/cmd/edit/firmware_set.go
+++ b/cmd/edit/firmware_set.go
@@ -5,11 +5,12 @@ import (
 	"log"
 
 	"github.com/google/uuid"
+	"github.com/spf13/cobra"
+	ss "go.hollow.sh/serverservice/pkg/api/v1"
+
 	mctl "github.com/metal-toolbox/mctl/cmd"
 	"github.com/metal-toolbox/mctl/internal/app"
 	"github.com/metal-toolbox/mctl/pkg/model"
-	"github.com/spf13/cobra"
-	ss "go.hollow.sh/serverservice/pkg/api/v1"
 )
 
 var (
@@ -96,16 +97,12 @@ var editFirmwareSet = &cobra.Command{
 }
 
 func init() {
-	cmdFlags := editFirmwareSet.PersistentFlags()
-	cmdFlags.StringVar(&editFWSetFlags.ID, "uuid", "", "UUID of firmware set to be edited")
-	cmdFlags.StringVar(&editFWSetFlags.FirmwareSetName, "name", "", "Update name for the firmware set")
-	cmdFlags.StringToStringVar(&editFWSetFlags.Labels, "labels", nil, "Labels to assign to the firmware set - 'vendor=foo,model=bar'")
+	mctl.AddFirmwareSetFlag(editFirmwareSet, &editFWSetFlags.ID)
+	mctl.AddNameFlag(editFirmwareSet, &editFWSetFlags.ID, "New name of the firmware set")
+	mctl.AddLabelsFlag(editFirmwareSet, &editFWSetFlags.Labels,
+		"Labels to assign to the firmware set - 'vendor=foo,model=bar'")
+	mctl.AddFirmwareAddIDsFlag(editFirmwareSet, &editFWSetFlags.AddFirmwareUUIDs)
+	mctl.AddFirmwareRemoveIDsFlag(editFirmwareSet, &editFWSetFlags.RemoveFirmwareUUIDs)
 
-	if err := editFirmwareSet.MarkPersistentFlagRequired("uuid"); err != nil {
-		log.Fatal(err)
-	}
-
-	cmdFlags.StringSliceVar(&editFWSetFlags.RemoveFirmwareUUIDs, "remove-firmware-uuids", []string{}, "UUIDs of firmware to be removed from the set")
-	cmdFlags.StringSliceVar(&editFWSetFlags.AddFirmwareUUIDs, "add-firmware-uuids", []string{}, "UUIDs of firmware to be added to the set")
-
+	mctl.RequireFlag(editFirmwareSet, mctl.FirmwareSetFlag)
 }

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -1,0 +1,266 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+type flagDetails struct {
+	name  string
+	short string
+}
+
+var (
+	ConfigFileFlag       = &flagDetails{name: "config", short: "c"}
+	ReAuthFlag           = &flagDetails{name: "reauth"}
+	ServerFlag           = &flagDetails{name: "server", short: "s"}
+	SkipFWStatusFlag     = &flagDetails{name: "skip-fw-status"}
+	SkipBiosConfigFlag   = &flagDetails{name: "skip-bios-config"}
+	FromFileFlag         = &flagDetails{name: "from-file", short: "F"}
+	FirmwareIDsFlag      = &flagDetails{name: "firmware-ids", short: "U"}
+	NameFlag             = &flagDetails{name: "name", short: "n"}
+	LabelsFlag           = &flagDetails{name: "labels", short: "l"}
+	FacilityFlag         = &flagDetails{name: "facility"}
+	AddressFlag          = &flagDetails{name: "address", short: "a"}
+	UsernameFlag         = &flagDetails{name: "username", short: "u"}
+	PasswordFlag         = &flagDetails{name: "password", short: "p"}
+	FirmwareFlag         = &flagDetails{name: "firmware", short: "f"}
+	FirmwareSetFlag      = &flagDetails{name: "set-id"}
+	FirmwareAddFlag      = &flagDetails{name: "add-firmware-ids"}
+	FirmwareRemoveFlag   = &flagDetails{name: "remove-firmware-ids"}
+	MacAOCFlag           = &flagDetails{name: "aoc-mac"}
+	MacBMCFlag           = &flagDetails{name: "bmc-mac"}
+	OutputFlag           = &flagDetails{name: "output", short: "o"}
+	ForceFlag            = &flagDetails{name: "force"}
+	DryRunFlag           = &flagDetails{name: "dry-run"}
+	SkipBmcResetFlag     = &flagDetails{name: "skip-bmc-reset"}
+	PowerOffRequiredFlag = &flagDetails{name: "power-off-required"}
+	ModelFlag            = &flagDetails{name: "model", short: "m"}
+	VendorFlag           = &flagDetails{name: "vendor", short: "v"}
+	SlugFlag             = &flagDetails{name: "slug"}
+	WithRecordsFlag      = &flagDetails{name: "with-records"}
+	PageFlag             = &flagDetails{name: "page"}
+	LimitFlag            = &flagDetails{name: "limit"}
+	WithBMCErrorsFlag    = &flagDetails{name: "with-bmc-errors"}
+	WithCredsFlag        = &flagDetails{name: "with-creds"}
+	PrintTableFlag       = &flagDetails{name: "table", short: "t"}
+	BiosConfigFlag       = &flagDetails{name: "bios-config"}
+	ListComponentsFlag   = &flagDetails{name: "list-components"}
+	ServerSerialFlag     = &flagDetails{name: "serial"}
+
+	OutputTypeJSON outputType = "json"
+	OutputTypeText outputType = "text"
+)
+
+type outputType string
+
+func (o *outputType) String() string {
+	return string(*o)
+}
+
+func (o *outputType) Type() string {
+	return "outputType"
+}
+
+func (o *outputType) Set(value string) error {
+	value = strings.ToLower(value)
+
+	switch value {
+	case OutputTypeJSON.String(), OutputTypeText.String():
+		*o = outputType(value)
+		return nil
+	default:
+		return errors.New("unsupported output type")
+	}
+}
+
+//nolint:staticcheck // SA5011 log.Fatalf will make sure we don't continue if flag is nil
+func RequireFlag(cmd *cobra.Command, flagDetail *flagDetails) {
+	flag := cmd.PersistentFlags().Lookup(flagDetail.name)
+	if flag == nil {
+		log.Fatalf("no flag with name '%s'", flagDetail.name)
+	}
+
+	if err := cmd.MarkPersistentFlagRequired(flag.Name); err != nil {
+		log.Fatal(err)
+	}
+
+	var flagUsage string
+	if flag.Shorthand != "" {
+		flagUsage = "-" + flag.Shorthand
+	} else {
+		flagUsage = "--" + flag.Name
+	}
+
+	valueType := strings.ToUpper(strings.ReplaceAll(flag.Name, "-", ""))
+
+	flag.Usage = "[required] " + flag.Usage
+	cmd.Use = fmt.Sprintf("%s %s %s", cmd.Use, flagUsage, valueType)
+}
+
+func MutuallyExclusiveFlags(cmd *cobra.Command, flags ...*flagDetails) {
+	flagNames := make([]string, len(flags))
+
+	for i, f := range flags {
+		flagNames[i] = f.name
+	}
+
+	cmd.MarkFlagsMutuallyExclusive(flagNames...)
+}
+
+func AddConfigFileFlag(cmd *cobra.Command, ptr *string) {
+	cmd.PersistentFlags().StringVarP(ptr, ConfigFileFlag.name, ConfigFileFlag.short, "",
+		"config file (default is $XDG_CONFIG_HOME/mctl/config.yml)")
+}
+
+func AddReAuthFlag(cmd *cobra.Command, ptr *bool) {
+	cmd.PersistentFlags().BoolVar(ptr, ReAuthFlag.name, false, "re-authenticate with oauth services")
+}
+
+func AddServerFlag(cmd *cobra.Command, ptr *string) {
+	cmd.PersistentFlags().StringVarP(ptr, ServerFlag.name, ServerFlag.short, "", "ID of the server")
+}
+
+func AddSkipFWStatusFlag(cmd *cobra.Command, ptr *bool) {
+	cmd.PersistentFlags().BoolVar(ptr, SkipFWStatusFlag.name, false, "Skip firmware status data collection")
+}
+
+func AddSkipBiosConfigFlag(cmd *cobra.Command, ptr *bool) {
+	cmd.PersistentFlags().BoolVar(ptr, SkipBiosConfigFlag.name, false, "Skip BIOS configuration data collection")
+}
+
+func AddFromFileFlag(cmd *cobra.Command, ptr *string, usage string) {
+	cmd.PersistentFlags().StringVarP(ptr, FromFileFlag.name, FromFileFlag.short, "", usage)
+}
+
+func AddFirmwareIDsFlag(cmd *cobra.Command, ptr *[]string) {
+	usage := "comma separated list of firmware IDs"
+	cmd.PersistentFlags().StringSliceVarP(ptr, FirmwareIDsFlag.name, FirmwareIDsFlag.short, []string{}, usage)
+}
+
+func AddNameFlag(cmd *cobra.Command, ptr *string, usage string) {
+	cmd.PersistentFlags().StringVarP(ptr, NameFlag.name, NameFlag.short, "", usage)
+}
+
+//nolint:gocritic // ptrToRefParam we need the pointer map argument
+func AddLabelsFlag(cmd *cobra.Command, ptr *map[string]string, usage string) {
+	cmd.PersistentFlags().StringToStringVarP(ptr, LabelsFlag.name, LabelsFlag.short, nil, usage)
+}
+
+func AddFacilityFlag(cmd *cobra.Command, ptr *string) {
+	cmd.PersistentFlags().StringVar(ptr, FacilityFlag.name, "", "facility name")
+}
+
+func AddAddressFlag(cmd *cobra.Command, ptr *string) {
+	cmd.PersistentFlags().StringVarP(ptr, AddressFlag.name, AddressFlag.short, "", "ip address of the server")
+}
+
+func AddUsernameFlag(cmd *cobra.Command, ptr *string) {
+	cmd.PersistentFlags().StringVarP(ptr, UsernameFlag.name, UsernameFlag.short, "", "username of the user")
+}
+
+func AddPasswordFlag(cmd *cobra.Command, ptr *string) {
+	cmd.PersistentFlags().StringVarP(ptr, PasswordFlag.name, PasswordFlag.short, "", "password of the user")
+}
+
+func AddFirmwareFlag(cmd *cobra.Command, ptr *string) {
+	cmd.PersistentFlags().StringVarP(ptr, FirmwareFlag.name, FirmwareFlag.short, "", "ID of the firmware")
+}
+
+func AddFirmwareSetFlag(cmd *cobra.Command, ptr *string) {
+	cmd.PersistentFlags().StringVar(ptr, FirmwareSetFlag.name, "", "ID of the firmware set")
+}
+
+func AddFirmwareAddIDsFlag(cmd *cobra.Command, ptr *[]string) {
+	usage := "comma separated list of firmware IDs to be added"
+	cmd.PersistentFlags().StringSliceVar(ptr, FirmwareAddFlag.name, []string{}, usage)
+}
+
+func AddFirmwareRemoveIDsFlag(cmd *cobra.Command, ptr *[]string) {
+	usage := "comma separated list of firmware IDs to be removed"
+	cmd.PersistentFlags().StringSliceVar(ptr, FirmwareRemoveFlag.name, []string{}, usage)
+}
+
+func AddMacAOCFlag(cmd *cobra.Command, ptr *string) {
+	cmd.PersistentFlags().StringVar(ptr, MacAOCFlag.name, "", "aoc mac address")
+}
+
+func AddMacBMCFlag(cmd *cobra.Command, ptr *string) {
+	cmd.PersistentFlags().StringVar(ptr, MacBMCFlag.name, "", "bmc mac address")
+}
+
+func AddOutputFlag(cmd *cobra.Command, ptr *string) {
+	*ptr = OutputTypeJSON.String() // default value
+	outputFlag := (*outputType)(ptr)
+	cmd.PersistentFlags().VarP(outputFlag, OutputFlag.name, OutputFlag.short, "{json|text}")
+}
+
+func AddForceFlag(cmd *cobra.Command, ptr *bool, usage string) {
+	cmd.PersistentFlags().BoolVar(ptr, ForceFlag.name, false, usage)
+}
+
+func AddDryRunFlag(cmd *cobra.Command, ptr *bool, usage string) {
+	cmd.PersistentFlags().BoolVar(ptr, DryRunFlag.name, false, usage)
+}
+
+func AddSkipBmcResetFlag(cmd *cobra.Command, ptr *bool) {
+	cmd.PersistentFlags().BoolVar(ptr, SkipBmcResetFlag.name, false, "skip BMC reset before firmware install")
+}
+
+func AddPowerOffRequiredFlag(cmd *cobra.Command, ptr *bool, usage string) {
+	cmd.PersistentFlags().BoolVar(ptr, PowerOffRequiredFlag.name, false, usage)
+}
+
+func AddModelFlag(cmd *cobra.Command, ptr *string) {
+	cmd.PersistentFlags().StringVarP(ptr, ModelFlag.name, ModelFlag.short, "", "filter by model")
+}
+
+func AddVendorFlag(cmd *cobra.Command, ptr *string) {
+	cmd.PersistentFlags().StringVarP(ptr, VendorFlag.name, VendorFlag.short, "", "filter by vendor")
+}
+
+func AddSlugFlag(cmd *cobra.Command, ptr *string, usage string) {
+	cmd.PersistentFlags().StringVar(ptr, SlugFlag.name, "", usage)
+}
+
+func AddWithRecordsFlag(cmd *cobra.Command, ptr *bool) {
+	cmd.PersistentFlags().BoolVar(ptr, WithRecordsFlag.name, false,
+		"print record count found with pagination info and return")
+}
+
+func AddPageFlag(cmd *cobra.Command, ptr *int) {
+	cmd.PersistentFlags().IntVar(ptr, PageFlag.name, 0, "limit results to page (for use with --limit)")
+}
+
+func AddPageLimitFlag(cmd *cobra.Command, ptr *int) {
+	defaultLimit := 10
+	cmd.PersistentFlags().IntVar(ptr, LimitFlag.name, defaultLimit, "limit results returned")
+}
+
+func AddWithBMCErrorsFlag(cmd *cobra.Command, ptr *bool) {
+	cmd.PersistentFlags().BoolVar(ptr, WithBMCErrorsFlag.name, false, "include BMC errors")
+}
+
+func AddWithCredsFlag(cmd *cobra.Command, ptr *bool) {
+	cmd.PersistentFlags().BoolVar(ptr, WithCredsFlag.name, false, "include credentials")
+}
+
+func AddPrintTableFlag(cmd *cobra.Command, ptr *bool) {
+	cmd.PersistentFlags().BoolVar(ptr, PrintTableFlag.name, false, "format output in a table")
+}
+
+func AddBIOSConfigFlag(cmd *cobra.Command, ptr *bool) {
+	cmd.PersistentFlags().BoolVar(ptr, BiosConfigFlag.name, false, "print bios configuration")
+}
+
+func AddListComponentsFlag(cmd *cobra.Command, ptr *bool) {
+	cmd.PersistentFlags().BoolVar(ptr, ListComponentsFlag.name, false, "include component data")
+}
+
+func AddServerSerialFlag(cmd *cobra.Command, ptr *string) {
+	cmd.PersistentFlags().StringVar(ptr, ServerSerialFlag.name, "", "filter by server serial")
+}

--- a/cmd/get/bios-config.go
+++ b/cmd/get/bios-config.go
@@ -7,10 +7,11 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
-	mctl "github.com/metal-toolbox/mctl/cmd"
-	"github.com/metal-toolbox/mctl/internal/app"
 	"github.com/spf13/cobra"
 	serverservice "go.hollow.sh/serverservice/pkg/api/v1"
+
+	mctl "github.com/metal-toolbox/mctl/cmd"
+	"github.com/metal-toolbox/mctl/internal/app"
 )
 
 type getBiosConfigFlags struct {
@@ -81,9 +82,6 @@ func biosConfigFromNamespaces(ctx context.Context, serverID uuid.UUID, client *s
 func init() {
 	flagsDefinedGetBiosConfig = &getBiosConfigFlags{}
 
-	getBiosConfig.PersistentFlags().StringVar(&flagsDefinedGetBiosConfig.serverID, "server", "", "server UUID")
-
-	if err := getBiosConfig.MarkPersistentFlagRequired("server"); err != nil {
-		log.Fatal(err)
-	}
+	mctl.AddServerFlag(getBiosConfig, &flagsDefinedGetBiosConfig.serverID)
+	mctl.RequireFlag(getBiosConfig, mctl.ServerFlag)
 }

--- a/cmd/get/bom.go
+++ b/cmd/get/bom.go
@@ -3,10 +3,11 @@ package get
 import (
 	"log"
 
-	mctl "github.com/metal-toolbox/mctl/cmd"
-	"github.com/metal-toolbox/mctl/internal/app"
 	"github.com/spf13/cobra"
 	serverservice "go.hollow.sh/serverservice/pkg/api/v1"
+
+	mctl "github.com/metal-toolbox/mctl/cmd"
+	"github.com/metal-toolbox/mctl/internal/app"
 )
 
 type getBomInfoByBmcMacAddressFlags struct {
@@ -58,8 +59,8 @@ var getBomInfoByMacAddress = &cobra.Command{
 func init() {
 	flagsGetBomByMacAddress = &getBomInfoByBmcMacAddressFlags{}
 
-	getBomInfoByMacAddress.PersistentFlags().StringVar(&flagsGetBomByMacAddress.aocMacAddr, "aoc-mac", "", "get bom info by aoc mac address")
-	getBomInfoByMacAddress.PersistentFlags().StringVar(&flagsGetBomByMacAddress.bmcMacAddr, "bmc-mac", "", "get bom info by bmc mac address")
+	mctl.AddMacAOCFlag(getBomInfoByMacAddress, &flagsGetBomByMacAddress.aocMacAddr)
+	mctl.AddMacBMCFlag(getBomInfoByMacAddress, &flagsGetBomByMacAddress.bmcMacAddr)
 
-	getBomInfoByMacAddress.MarkFlagsMutuallyExclusive("aoc-mac", "bmc-mac")
+	mctl.MutuallyExclusiveFlags(getBomInfoByMacAddress, mctl.MacAOCFlag, mctl.MacBMCFlag)
 }

--- a/cmd/get/condition.go
+++ b/cmd/get/condition.go
@@ -4,9 +4,10 @@ import (
 	"log"
 
 	"github.com/google/uuid"
+	"github.com/spf13/cobra"
+
 	mctl "github.com/metal-toolbox/mctl/cmd"
 	"github.com/metal-toolbox/mctl/internal/app"
-	"github.com/spf13/cobra"
 )
 
 type getConditionFlags struct {
@@ -46,10 +47,6 @@ var getCondition = &cobra.Command{
 func init() {
 	flagsDefinedGetCondition = &getConditionFlags{}
 
-	getCondition.Flags().StringVarP(&flagsDefinedGetCondition.id, "server", "s", "", "server UUID")
-
-	if err := getCondition.MarkFlagRequired("server"); err != nil {
-		log.Fatal(err)
-	}
-
+	mctl.AddServerFlag(getCondition, &flagsDefinedGetCondition.id)
+	mctl.RequireFlag(getCondition, mctl.ServerFlag)
 }

--- a/cmd/get/firmware-set.go
+++ b/cmd/get/firmware-set.go
@@ -8,11 +8,12 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
-	mctl "github.com/metal-toolbox/mctl/cmd"
-	"github.com/metal-toolbox/mctl/internal/app"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	serverservice "go.hollow.sh/serverservice/pkg/api/v1"
+
+	mctl "github.com/metal-toolbox/mctl/cmd"
+	"github.com/metal-toolbox/mctl/internal/app"
 )
 
 type getFirmwareSetFlags struct {
@@ -40,8 +41,7 @@ var getFirmwareSet = &cobra.Command{
 		}
 
 		if flagsDefinedGetFirmwareSet.id == "" && flagsDefinedGetFirmwareSet.serverID == "" {
-			//nolint:errcheck // returns nil
-			cmd.Help()
+			_ = cmd.Help()
 			os.Exit(1)
 		}
 
@@ -113,9 +113,8 @@ func firmwareSetForServer(ctx context.Context, client *serverservice.Client, ser
 func init() {
 	flagsDefinedGetFirmwareSet = &getFirmwareSetFlags{}
 
-	getFirmwareSet.PersistentFlags().StringVar(&flagsDefinedGetFirmwareSet.id, "id", "", "firmware set UUID")
-	getFirmwareSet.PersistentFlags().StringVar(&flagsDefinedGetFirmwareSet.serverID, "server", "", "server UUID")
+	mctl.AddServerFlag(getFirmwareSet, &flagsDefinedGetFirmwareSet.serverID)
+	mctl.AddFirmwareSetFlag(getFirmwareSet, &flagsDefinedGetFirmwareSet.id)
 
-	getFirmwareSet.MarkFlagsMutuallyExclusive("id", "server")
-
+	mctl.RequireFlag(getFirmwareSet, mctl.ServerFlag)
 }

--- a/cmd/get/firmware.go
+++ b/cmd/get/firmware.go
@@ -6,9 +6,10 @@ import (
 	"os"
 
 	"github.com/google/uuid"
+	"github.com/spf13/cobra"
+
 	mctl "github.com/metal-toolbox/mctl/cmd"
 	"github.com/metal-toolbox/mctl/internal/app"
-	"github.com/spf13/cobra"
 )
 
 type getFirmwareFlags struct {
@@ -52,9 +53,6 @@ var getFirmware = &cobra.Command{
 func init() {
 	flagsDefinedGetFirmware = &getFirmwareFlags{}
 
-	getFirmware.PersistentFlags().StringVarP(&flagsDefinedGetFirmware.id, "firmware-id", "f", "", "firmware UUID")
-
-	if err := getFirmware.MarkPersistentFlagRequired("firmware-id"); err != nil {
-		log.Fatal(err)
-	}
+	mctl.AddFirmwareFlag(getFirmware, &flagsDefinedGetFirmware.id)
+	mctl.RequireFlag(getFirmware, mctl.FirmwareFlag)
 }

--- a/cmd/get/get.go
+++ b/cmd/get/get.go
@@ -1,8 +1,9 @@
 package get
 
 import (
-	"github.com/metal-toolbox/mctl/cmd"
 	"github.com/spf13/cobra"
+
+	"github.com/metal-toolbox/mctl/cmd"
 )
 
 var (
@@ -13,8 +14,7 @@ var cmdGet = &cobra.Command{
 	Use:   "get",
 	Short: "Get resource",
 	Run: func(cmd *cobra.Command, args []string) {
-		//nolint:errcheck // returns nil
-		cmd.Help()
+		_ = cmd.Help()
 	},
 }
 
@@ -27,5 +27,5 @@ func init() {
 	cmdGet.AddCommand(getBiosConfig)
 	cmdGet.AddCommand(getBomInfoByMacAddress)
 
-	cmdGet.PersistentFlags().StringVarP(&output, "output", "o", "json", "{json|text}")
+	cmd.AddOutputFlag(cmdGet, &output)
 }

--- a/cmd/get/server.go
+++ b/cmd/get/server.go
@@ -9,14 +9,15 @@ import (
 
 	"github.com/dustin/go-humanize"
 	"github.com/google/uuid"
-	mctl "github.com/metal-toolbox/mctl/cmd"
-	"github.com/metal-toolbox/mctl/internal/app"
 	rts "github.com/metal-toolbox/rivets/serverservice"
 	rt "github.com/metal-toolbox/rivets/types"
 	"github.com/olekukonko/tablewriter"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	ss "go.hollow.sh/serverservice/pkg/api/v1"
+
+	mctl "github.com/metal-toolbox/mctl/cmd"
+	"github.com/metal-toolbox/mctl/internal/app"
 )
 
 type getServerFlags struct {
@@ -199,16 +200,12 @@ func components(ctx context.Context, c *ss.Client, id uuid.UUID) ([]*rt.Componen
 func init() {
 	cmdArgs = &getServerFlags{}
 
-	cmdPFlags := getServer.PersistentFlags()
+	mctl.AddServerFlag(getServer, &cmdArgs.id)
+	mctl.AddSlugFlag(getServer, &cmdArgs.component, "list component on server by slug (drive/nic/cpu..)")
+	mctl.AddWithCredsFlag(getServer, &cmdArgs.creds)
+	mctl.AddPrintTableFlag(getServer, &cmdArgs.table)
+	mctl.AddBIOSConfigFlag(getServer, &cmdArgs.biosconfig)
+	mctl.AddListComponentsFlag(getServer, &cmdArgs.listComponents)
 
-	cmdPFlags.StringVar(&cmdArgs.id, "id", "", "server UUID")
-	cmdPFlags.StringVar(&cmdArgs.component, "component", "", "list component on server by slug (drive/nic/cpu..)")
-	cmdPFlags.BoolVarP(&cmdArgs.listComponents, "list-components", "l", false, "include component data")
-	cmdPFlags.BoolVarP(&cmdArgs.biosconfig, "bioscfg", "b", false, "print bios configuration")
-	cmdPFlags.BoolVar(&cmdArgs.creds, "creds", false, "include BMC credentials in result")
-	cmdPFlags.BoolVarP(&cmdArgs.table, "table", "t", false, "format output in a table")
-
-	if err := getServer.MarkPersistentFlagRequired("id"); err != nil {
-		log.Fatal(err)
-	}
+	mctl.RequireFlag(getServer, mctl.ServerFlag)
 }

--- a/cmd/install/firmware_set.go
+++ b/cmd/install/firmware_set.go
@@ -6,13 +6,15 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
-	"github.com/metal-toolbox/mctl/internal/app"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
-	mctl "github.com/metal-toolbox/mctl/cmd"
+	"github.com/metal-toolbox/mctl/internal/app"
+
 	rctypes "github.com/metal-toolbox/rivets/condition"
 	serverservice "go.hollow.sh/serverservice/pkg/api/v1"
+
+	mctl "github.com/metal-toolbox/mctl/cmd"
 )
 
 type installFirmwareSetFlags struct {
@@ -130,15 +132,15 @@ func firmwareSetForInstall(ctx context.Context, client *serverservice.Client, se
 func init() {
 	flagsDefinedInstallFwSet = &installFirmwareSetFlags{}
 
-	install.AddCommand(installFirmwareSet)
-	installFirmwareSet.PersistentFlags().StringVar(&flagsDefinedInstallFwSet.serverID, "server", "", "server UUID")
-	installFirmwareSet.PersistentFlags().StringVar(&flagsDefinedInstallFwSet.firmwareSetID, "id", "", "firmware set UUID")
-	installFirmwareSet.PersistentFlags().BoolVar(&flagsDefinedInstallFwSet.forceInstall, "force", false, "force install (skips firmware version check)")
-	installFirmwareSet.PersistentFlags().BoolVar(&flagsDefinedInstallFwSet.dryRun, "dry-run", false, "Run install process in dry-run (skips firmware install)")
-	installFirmwareSet.PersistentFlags().BoolVar(&flagsDefinedInstallFwSet.skipBMCReset, "skip-bmc-reset", false, "skip BMC reset before firmware install")
-	installFirmwareSet.PersistentFlags().BoolVar(&flagsDefinedInstallFwSet.requireHostPoweredOff, "require-host-powered-off", false, "require host to be powered off before proceeding install")
+	mctl.AddServerFlag(installFirmwareSet, &flagsDefinedInstallFwSet.serverID)
+	mctl.AddFirmwareSetFlag(installFirmwareSet, &flagsDefinedInstallFwSet.firmwareSetID)
+	mctl.AddForceFlag(installFirmwareSet, &flagsDefinedInstallFwSet.forceInstall,
+		"force install (skips firmware version check)")
+	mctl.AddDryRunFlag(installFirmwareSet, &flagsDefinedInstallFwSet.dryRun,
+		"Run install process in dry-run (skips firmware install)")
+	mctl.AddSkipBmcResetFlag(installFirmwareSet, &flagsDefinedInstallFwSet.skipBMCReset)
+	mctl.AddPowerOffRequiredFlag(installFirmwareSet, &flagsDefinedInstallFwSet.requireHostPoweredOff,
+		"require host to be powered off before proceeding install")
 
-	if err := installFirmwareSet.MarkPersistentFlagRequired("server"); err != nil {
-		log.Fatal(err)
-	}
+	mctl.RequireFlag(installFirmwareSet, mctl.ServerFlag)
 }

--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -1,19 +1,22 @@
 package install
 
 import (
-	"github.com/metal-toolbox/mctl/cmd"
 	"github.com/spf13/cobra"
+
+	"github.com/metal-toolbox/mctl/cmd"
 )
 
 var install = &cobra.Command{
 	Use:   "install",
 	Short: "Install actions",
 	Run: func(cmd *cobra.Command, args []string) {
-		//nolint:errcheck // returns nil
-		cmd.Help()
+		_ = cmd.Help()
 	},
 }
 
 func init() {
 	cmd.RootCmd.AddCommand(install)
+
+	install.AddCommand(installFirmwareSet)
+	install.AddCommand(installStatus)
 }

--- a/cmd/install/status.go
+++ b/cmd/install/status.go
@@ -6,11 +6,11 @@ import (
 	"log"
 
 	"github.com/google/uuid"
+	rctypes "github.com/metal-toolbox/rivets/condition"
+	"github.com/spf13/cobra"
 
 	mctl "github.com/metal-toolbox/mctl/cmd"
 	"github.com/metal-toolbox/mctl/internal/app"
-	rctypes "github.com/metal-toolbox/rivets/condition"
-	"github.com/spf13/cobra"
 )
 
 var serverIDStr string
@@ -50,12 +50,6 @@ func statusCheck(ctx context.Context) {
 }
 
 func init() {
-	flags := installStatus.Flags()
-	flags.StringVarP(&serverIDStr, "server", "s", "", "server id (typically a UUID)")
-
-	if err := installStatus.MarkFlagRequired("server"); err != nil {
-		log.Fatalf("marking server flag as required: %s", err.Error())
-	}
-
-	install.AddCommand(installStatus)
+	mctl.AddServerFlag(installStatus, &serverIDStr)
+	mctl.RequireFlag(installStatus, mctl.ServerFlag)
 }

--- a/cmd/list/component.go
+++ b/cmd/list/component.go
@@ -4,10 +4,11 @@ import (
 	"log"
 	"os"
 
-	mctl "github.com/metal-toolbox/mctl/cmd"
-	"github.com/metal-toolbox/mctl/internal/app"
 	"github.com/spf13/cobra"
 	serverservice "go.hollow.sh/serverservice/pkg/api/v1"
+
+	mctl "github.com/metal-toolbox/mctl/cmd"
+	"github.com/metal-toolbox/mctl/internal/app"
 )
 
 type listComponentFlags struct {
@@ -81,14 +82,12 @@ var listComponent = &cobra.Command{
 func init() {
 	flagsListComponent = &listComponentFlags{}
 
-	listComponent.PersistentFlags().BoolVar(&flagsListComponent.records, "records", false, "print record count found with pagination info and return")
-	listComponent.PersistentFlags().StringVar(&flagsListComponent.slug, "slug", "", "filter by component slug (nic/drive/bmc/bios...)")
-	listComponent.PersistentFlags().StringVar(&flagsListComponent.vendor, "vendor", "", "filter by component vendor")
-	listComponent.PersistentFlags().StringVar(&flagsListComponent.model, "model", "", "filter by one or more component models")
-	listComponent.PersistentFlags().IntVar(&flagsListComponent.page, "page", 0, "limit results to page (for use with --limit)")
-	listComponent.PersistentFlags().IntVar(&flagsListComponent.limit, "limit", 10, "limit results returned") // nolint:gomnd // value is obvious as is
+	mctl.AddWithRecordsFlag(listComponent, &flagsListComponent.records)
+	mctl.AddSlugFlag(listComponent, &flagsListComponent.slug, "filter by component slug (nic/drive/bmc/bios...)")
+	mctl.AddVendorFlag(listComponent, &flagsListComponent.vendor)
+	mctl.AddModelFlag(listComponent, &flagsListComponent.model)
+	mctl.AddPageFlag(listComponent, &flagsListComponent.page)
+	mctl.AddPageLimitFlag(listComponent, &flagsListComponent.limit)
 
-	if err := listComponent.MarkPersistentFlagRequired("slug"); err != nil {
-		log.Fatal(err)
-	}
+	mctl.RequireFlag(listComponent, mctl.SlugFlag)
 }

--- a/cmd/list/firmware.go
+++ b/cmd/list/firmware.go
@@ -6,11 +6,12 @@ import (
 	"os"
 	"strings"
 
-	mctl "github.com/metal-toolbox/mctl/cmd"
-	"github.com/metal-toolbox/mctl/internal/app"
 	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
 	serverservice "go.hollow.sh/serverservice/pkg/api/v1"
+
+	mctl "github.com/metal-toolbox/mctl/cmd"
+	"github.com/metal-toolbox/mctl/internal/app"
 )
 
 type listFirmwareFlags struct {
@@ -60,7 +61,7 @@ var listFirmware = &cobra.Command{
 			log.Fatal("serverservice client returned error: ", err)
 		}
 
-		if outputJSON {
+		if output == mctl.OutputTypeJSON.String() {
 			printJSON(firmware)
 			os.Exit(0)
 		}

--- a/cmd/list/firmware_set.go
+++ b/cmd/list/firmware_set.go
@@ -5,13 +5,13 @@ import (
 	"os"
 	"strings"
 
+	"github.com/olekukonko/tablewriter"
+	"github.com/spf13/cobra"
+	serverservice "go.hollow.sh/serverservice/pkg/api/v1"
+
 	mctl "github.com/metal-toolbox/mctl/cmd"
 	"github.com/metal-toolbox/mctl/internal/app"
 	"github.com/metal-toolbox/mctl/pkg/model"
-	"github.com/olekukonko/tablewriter"
-	"github.com/spf13/cobra"
-
-	serverservice "go.hollow.sh/serverservice/pkg/api/v1"
 )
 
 type listFirmwareSetFlags struct {
@@ -49,7 +49,7 @@ var listFirmwareSet = &cobra.Command{
 			}
 		}
 
-		if outputJSON {
+		if output == mctl.OutputTypeJSON.String() {
 			printJSON(fwSet)
 			os.Exit(0)
 		}
@@ -78,6 +78,6 @@ var listFirmwareSet = &cobra.Command{
 func init() {
 	flagsDefinedListFwSet = &listFirmwareSetFlags{}
 
-	listFirmwareSet.PersistentFlags().StringVar(&flagsDefinedListFwSet.vendor, "vendor", "", "filter by server vendor")
-	listFirmwareSet.PersistentFlags().StringVar(&flagsDefinedListFwSet.model, "model", "", "filter by server model")
+	mctl.AddModelFlag(listFirmwareSet, &flagsDefinedListFwSet.model)
+	mctl.AddVendorFlag(listFirmwareSet, &flagsDefinedListFwSet.vendor)
 }

--- a/cmd/list/list.go
+++ b/cmd/list/list.go
@@ -1,20 +1,20 @@
 package list
 
 import (
-	"github.com/metal-toolbox/mctl/cmd"
 	"github.com/spf13/cobra"
+
+	"github.com/metal-toolbox/mctl/cmd"
 )
 
 var (
-	outputJSON bool
+	output string
 )
 
 var list = &cobra.Command{
 	Use:   "list",
 	Short: "List resources",
 	Run: func(cmd *cobra.Command, args []string) {
-		//nolint:errcheck // returns nil
-		cmd.Help()
+		_ = cmd.Help()
 	},
 }
 
@@ -25,5 +25,5 @@ func init() {
 	list.AddCommand(listComponent)
 	list.AddCommand(cmdListServer)
 
-	list.PersistentFlags().BoolVar(&outputJSON, "output-json", false, "Output listing as JSON")
+	cmd.AddOutputFlag(list, &output)
 }

--- a/cmd/list/server.go
+++ b/cmd/list/server.go
@@ -6,14 +6,14 @@ import (
 	"os"
 	"strings"
 
-	mctl "github.com/metal-toolbox/mctl/cmd"
-	"github.com/metal-toolbox/mctl/internal/app"
-	"github.com/olekukonko/tablewriter"
-	"github.com/spf13/cobra"
-
 	rts "github.com/metal-toolbox/rivets/serverservice"
 	rt "github.com/metal-toolbox/rivets/types"
+	"github.com/olekukonko/tablewriter"
+	"github.com/spf13/cobra"
 	ss "go.hollow.sh/serverservice/pkg/api/v1"
+
+	mctl "github.com/metal-toolbox/mctl/cmd"
+	"github.com/metal-toolbox/mctl/internal/app"
 )
 
 type listServerFlags struct {
@@ -193,14 +193,14 @@ func attributeParamsFromFlags(fl *listServerFlags) []ss.AttributeListParams {
 func init() {
 	fdlServer = &listServerFlags{}
 
-	cmdListServer.PersistentFlags().BoolVar(&fdlServer.records, "records", false, "only print record count matching filters")
-	cmdListServer.PersistentFlags().BoolVar(&fdlServer.table, "table", false, "print records in a table format")
-	cmdListServer.PersistentFlags().BoolVar(&fdlServer.bmcerrors, "bmcerrors", false, "list servers with BMC errors")
-	cmdListServer.PersistentFlags().BoolVar(&fdlServer.creds, "creds", false, "list BMC credentials in ")
-	cmdListServer.PersistentFlags().StringVar(&fdlServer.vendor, "vendor", "", "filter by server vendor")
-	cmdListServer.PersistentFlags().StringVar(&fdlServer.model, "model", "", "filter by server model")
-	cmdListServer.PersistentFlags().StringVar(&fdlServer.facility, "facility", "", "filter by facility code")
-	cmdListServer.PersistentFlags().StringVar(&fdlServer.serial, "serial", "", "filter by server serial")
-	cmdListServer.PersistentFlags().IntVar(&fdlServer.page, "page", 0, "limit results to page (for use with --limit)")
-	cmdListServer.PersistentFlags().IntVar(&fdlServer.limit, "limit", 10, "limit results returned") // nolint:gomnd // value is obvious as is
+	mctl.AddWithRecordsFlag(cmdListServer, &fdlServer.records)
+	mctl.AddVendorFlag(cmdListServer, &fdlServer.vendor)
+	mctl.AddModelFlag(cmdListServer, &fdlServer.model)
+	mctl.AddFacilityFlag(cmdListServer, &fdlServer.facility)
+	mctl.AddPageFlag(cmdListServer, &fdlServer.page)
+	mctl.AddPageLimitFlag(cmdListServer, &fdlServer.limit)
+	mctl.AddWithBMCErrorsFlag(cmdListServer, &fdlServer.bmcerrors)
+	mctl.AddWithCredsFlag(cmdListServer, &fdlServer.creds)
+	mctl.AddPrintTableFlag(cmdListServer, &fdlServer.table)
+	mctl.AddServerSerialFlag(cmdListServer, &fdlServer.serial)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -45,6 +45,6 @@ func Execute() {
 }
 
 func init() {
-	RootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $XDG_CONFIG_HOME/mctl/config.yml)")
-	RootCmd.PersistentFlags().BoolVar(&reAuth, "reauth", false, "re-authenticate with oauth services")
+	AddConfigFileFlag(RootCmd, &cfgFile)
+	AddReAuthFlag(RootCmd, &reAuth)
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -3,8 +3,9 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/metal-toolbox/mctl/internal/version"
 	"github.com/spf13/cobra"
+
+	"github.com/metal-toolbox/mctl/internal/version"
 )
 
 var cmdVersion = &cobra.Command{

--- a/docs/mctl.md
+++ b/docs/mctl.md
@@ -7,7 +7,7 @@ mctl is a CLI utility to interact with metal toolbox services
 ### Options
 
 ```
-      --config string   config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
+  -c, --config string   config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
   -h, --help            help for mctl
       --reauth          re-authenticate with oauth services
 ```

--- a/docs/mctl_collect.md
+++ b/docs/mctl_collect.md
@@ -11,14 +11,13 @@ mctl collect [flags]
 ### Options
 
 ```
-  -h, --help            help for collect
-  -s, --server string   server id (typically a UUID)
+  -h, --help   help for collect
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
+  -c, --config string   config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
       --reauth          re-authenticate with oauth services
 ```
 

--- a/docs/mctl_collect_inventory.md
+++ b/docs/mctl_collect_inventory.md
@@ -5,13 +5,14 @@
 Collect current server firmware status and bios configuration
 
 ```
-mctl collect inventory --server | -s <server uuid> [flags]
+mctl collect inventory -s SERVER [flags]
 ```
 
 ### Options
 
 ```
   -h, --help               help for inventory
+  -s, --server string      [required] ID of the server
       --skip-bios-config   Skip BIOS configuration data collection
       --skip-fw-status     Skip firmware status data collection
 ```
@@ -19,9 +20,8 @@ mctl collect inventory --server | -s <server uuid> [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
+  -c, --config string   config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
       --reauth          re-authenticate with oauth services
-  -s, --server string   server id (typically a UUID)
 ```
 
 ### SEE ALSO

--- a/docs/mctl_collect_status.md
+++ b/docs/mctl_collect_status.md
@@ -5,21 +5,21 @@
 check the progress of a inventory collection for a server
 
 ```
-mctl collect status --server | -s <server uuid> [flags]
+mctl collect status -s SERVER [flags]
 ```
 
 ### Options
 
 ```
-  -h, --help   help for status
+  -h, --help            help for status
+  -s, --server string   [required] ID of the server
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
+  -c, --config string   config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
       --reauth          re-authenticate with oauth services
-  -s, --server string   server id (typically a UUID)
 ```
 
 ### SEE ALSO

--- a/docs/mctl_completion.md
+++ b/docs/mctl_completion.md
@@ -19,7 +19,7 @@ See each sub-command's help for details on how to use the generated script.
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
+  -c, --config string   config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
       --reauth          re-authenticate with oauth services
 ```
 

--- a/docs/mctl_completion_bash.md
+++ b/docs/mctl_completion_bash.md
@@ -42,7 +42,7 @@ mctl completion bash
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
+  -c, --config string   config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
       --reauth          re-authenticate with oauth services
 ```
 

--- a/docs/mctl_completion_fish.md
+++ b/docs/mctl_completion_fish.md
@@ -33,7 +33,7 @@ mctl completion fish [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
+  -c, --config string   config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
       --reauth          re-authenticate with oauth services
 ```
 

--- a/docs/mctl_completion_powershell.md
+++ b/docs/mctl_completion_powershell.md
@@ -30,7 +30,7 @@ mctl completion powershell [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
+  -c, --config string   config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
       --reauth          re-authenticate with oauth services
 ```
 

--- a/docs/mctl_completion_zsh.md
+++ b/docs/mctl_completion_zsh.md
@@ -44,7 +44,7 @@ mctl completion zsh [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
+  -c, --config string   config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
       --reauth          re-authenticate with oauth services
 ```
 

--- a/docs/mctl_create.md
+++ b/docs/mctl_create.md
@@ -17,7 +17,7 @@ mctl create [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
+  -c, --config string   config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
       --reauth          re-authenticate with oauth services
 ```
 

--- a/docs/mctl_create_bom.md
+++ b/docs/mctl_create_bom.md
@@ -5,20 +5,20 @@
 Upload Bom File
 
 ```
-mctl create bom [flags]
+mctl create bom -F FROMFILE [flags]
 ```
 
 ### Options
 
 ```
-      --from-xlsx-file string   Xlsx file with bom informations
-  -h, --help                    help for bom
+  -F, --from-file string   [required] xlsx file with BOM information
+  -h, --help               help for bom
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
+  -c, --config string   config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
       --reauth          re-authenticate with oauth services
 ```
 

--- a/docs/mctl_create_firmware-set.md
+++ b/docs/mctl_create_firmware-set.md
@@ -5,22 +5,22 @@
 Create a firmware set
 
 ```
-mctl create firmware-set [flags]
+mctl create firmware-set -U FIRMWAREIDS -n NAME [flags]
 ```
 
 ### Options
 
 ```
-      --firmware-uuids strings   comma separated list of UUIDs of firmware to be included in the set to be created
-  -h, --help                     help for firmware-set
-      --labels stringToString    Labels to assign to the firmware set - 'vendor=foo,model=bar' (default [])
-      --name string              A name for the firmware set
+  -U, --firmware-ids strings    [required] comma separated list of firmware IDs
+  -h, --help                    help for firmware-set
+  -l, --labels stringToString   Labels to assign to the firmware set - 'vendor=foo,model=bar' (default [])
+  -n, --name string             [required] A name for the firmware set
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
+  -c, --config string   config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
       --reauth          re-authenticate with oauth services
 ```
 

--- a/docs/mctl_create_firmware.md
+++ b/docs/mctl_create_firmware.md
@@ -5,20 +5,20 @@
 Create firmware
 
 ```
-mctl create firmware [flags]
+mctl create firmware -F FROMFILE [flags]
 ```
 
 ### Options
 
 ```
-      --from-file string   JSON file with firmware configuration data
+  -F, --from-file string   [required] JSON file with firmware configuration data
   -h, --help               help for firmware
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
+  -c, --config string   config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
       --reauth          re-authenticate with oauth services
 ```
 

--- a/docs/mctl_create_server.md
+++ b/docs/mctl_create_server.md
@@ -5,24 +5,24 @@
 Enroll server and publish conditions
 
 ```
-mctl create server [flags]
+mctl create server -a ADDRESS -u USERNAME -p PASSWORD --facility FACILITY [flags]
 ```
 
 ### Options
 
 ```
-      --facility string    facility of the server
-  -h, --help               help for server
-      --ip string          ip of the server
-      --pwd string         password of the server
-      --server-id string   server id to be created. New id will be created if null.
-      --user string        username of the server
+  -a, --address string    [required] ip address of the server
+      --facility string   [required] facility name
+  -h, --help              help for server
+  -p, --password string   [required] password of the user
+  -s, --server string     ID of the server
+  -u, --username string   [required] username of the user
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
+  -c, --config string   config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
       --reauth          re-authenticate with oauth services
 ```
 

--- a/docs/mctl_delete.md
+++ b/docs/mctl_delete.md
@@ -17,7 +17,7 @@ mctl delete [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
+  -c, --config string   config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
       --reauth          re-authenticate with oauth services
 ```
 

--- a/docs/mctl_delete_firmware-set.md
+++ b/docs/mctl_delete_firmware-set.md
@@ -5,20 +5,20 @@
 Delete a firmware set
 
 ```
-mctl delete firmware-set [flags]
+mctl delete firmware-set --set-id SETID [flags]
 ```
 
 ### Options
 
 ```
-  -h, --help          help for firmware-set
-      --uuid string   UUID of firmware set to be deleted
+  -h, --help            help for firmware-set
+      --set-id string   [required] ID of the firmware set
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
+  -c, --config string   config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
       --reauth          re-authenticate with oauth services
 ```
 

--- a/docs/mctl_delete_firmware.md
+++ b/docs/mctl_delete_firmware.md
@@ -5,20 +5,20 @@
 Delete a firmware object
 
 ```
-mctl delete firmware [flags]
+mctl delete firmware -f FIRMWARE [flags]
 ```
 
 ### Options
 
 ```
-  -f, --firmware-id string   UUID of firmware object to be deleted
-  -h, --help                 help for firmware
+  -f, --firmware string   [required] ID of the firmware
+  -h, --help              help for firmware
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
+  -c, --config string   config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
       --reauth          re-authenticate with oauth services
 ```
 

--- a/docs/mctl_delete_server.md
+++ b/docs/mctl_delete_server.md
@@ -5,20 +5,20 @@
 Delete server from fleetDB
 
 ```
-mctl delete server [flags]
+mctl delete server -s SERVER [flags]
 ```
 
 ### Options
 
 ```
-  -h, --help               help for server
-      --server-id string   server id to be deleted
+  -h, --help            help for server
+  -s, --server string   [required] ID of the server
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
+  -c, --config string   config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
       --reauth          re-authenticate with oauth services
 ```
 

--- a/docs/mctl_edit.md
+++ b/docs/mctl_edit.md
@@ -17,7 +17,7 @@ mctl edit [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
+  -c, --config string   config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
       --reauth          re-authenticate with oauth services
 ```
 

--- a/docs/mctl_edit_firmware-set.md
+++ b/docs/mctl_edit_firmware-set.md
@@ -5,24 +5,24 @@
 Edit a firmware set
 
 ```
-mctl edit firmware-set [flags]
+mctl edit firmware-set --set-id SETID [flags]
 ```
 
 ### Options
 
 ```
-      --add-firmware-uuids strings      UUIDs of firmware to be added to the set
-  -h, --help                            help for firmware-set
-      --labels stringToString           Labels to assign to the firmware set - 'vendor=foo,model=bar' (default [])
-      --name string                     Update name for the firmware set
-      --remove-firmware-uuids strings   UUIDs of firmware to be removed from the set
-      --uuid string                     UUID of firmware set to be edited
+      --add-firmware-ids strings      comma separated list of firmware IDs to be added
+  -h, --help                          help for firmware-set
+  -l, --labels stringToString         Labels to assign to the firmware set - 'vendor=foo,model=bar' (default [])
+  -n, --name string                   New name of the firmware set
+      --remove-firmware-ids strings   comma separated list of firmware IDs to be removed
+      --set-id string                 [required] ID of the firmware set
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
+  -c, --config string   config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
       --reauth          re-authenticate with oauth services
 ```
 

--- a/docs/mctl_gendocs.md
+++ b/docs/mctl_gendocs.md
@@ -17,7 +17,7 @@ mctl gendocs [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
+  -c, --config string   config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
       --reauth          re-authenticate with oauth services
 ```
 

--- a/docs/mctl_get.md
+++ b/docs/mctl_get.md
@@ -11,14 +11,14 @@ mctl get [flags]
 ### Options
 
 ```
-  -h, --help            help for get
-  -o, --output string   {json|text} (default "json")
+  -h, --help                help for get
+  -o, --output outputType   {json|text} (default json)
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
+  -c, --config string   config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
       --reauth          re-authenticate with oauth services
 ```
 

--- a/docs/mctl_get_bios-config.md
+++ b/docs/mctl_get_bios-config.md
@@ -5,22 +5,22 @@
 Get bios configuration information for a server
 
 ```
-mctl get bios-config [flags]
+mctl get bios-config -s SERVER [flags]
 ```
 
 ### Options
 
 ```
   -h, --help            help for bios-config
-      --server string   server UUID
+  -s, --server string   [required] ID of the server
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
-  -o, --output string   {json|text} (default "json")
-      --reauth          re-authenticate with oauth services
+  -c, --config string       config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
+  -o, --output outputType   {json|text} (default json)
+      --reauth              re-authenticate with oauth services
 ```
 
 ### SEE ALSO

--- a/docs/mctl_get_bom.md
+++ b/docs/mctl_get_bom.md
@@ -11,17 +11,17 @@ mctl get bom [flags]
 ### Options
 
 ```
-      --aoc-mac string   get bom info by aoc mac address
-      --bmc-mac string   get bom info by bmc mac address
+      --aoc-mac string   aoc mac address
+      --bmc-mac string   bmc mac address
   -h, --help             help for bom
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
-  -o, --output string   {json|text} (default "json")
-      --reauth          re-authenticate with oauth services
+  -c, --config string       config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
+  -o, --output outputType   {json|text} (default json)
+      --reauth              re-authenticate with oauth services
 ```
 
 ### SEE ALSO

--- a/docs/mctl_get_condition.md
+++ b/docs/mctl_get_condition.md
@@ -5,22 +5,22 @@
 get the last server conditions performed
 
 ```
-mctl get condition [flags]
+mctl get condition -s SERVER [flags]
 ```
 
 ### Options
 
 ```
   -h, --help            help for condition
-  -s, --server string   server UUID
+  -s, --server string   [required] ID of the server
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
-  -o, --output string   {json|text} (default "json")
-      --reauth          re-authenticate with oauth services
+  -c, --config string       config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
+  -o, --output outputType   {json|text} (default json)
+      --reauth              re-authenticate with oauth services
 ```
 
 ### SEE ALSO

--- a/docs/mctl_get_firmware-set.md
+++ b/docs/mctl_get_firmware-set.md
@@ -5,23 +5,23 @@
 Get information for given firmware set identifier
 
 ```
-mctl get firmware-set [flags]
+mctl get firmware-set -s SERVER [flags]
 ```
 
 ### Options
 
 ```
   -h, --help            help for firmware-set
-      --id string       firmware set UUID
-      --server string   server UUID
+  -s, --server string   [required] ID of the server
+      --set-id string   ID of the firmware set
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
-  -o, --output string   {json|text} (default "json")
-      --reauth          re-authenticate with oauth services
+  -c, --config string       config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
+  -o, --output outputType   {json|text} (default json)
+      --reauth              re-authenticate with oauth services
 ```
 
 ### SEE ALSO

--- a/docs/mctl_get_firmware.md
+++ b/docs/mctl_get_firmware.md
@@ -5,22 +5,22 @@
 Get information for given firmware identifier
 
 ```
-mctl get firmware [flags]
+mctl get firmware -f FIRMWARE [flags]
 ```
 
 ### Options
 
 ```
-  -f, --firmware-id string   firmware UUID
-  -h, --help                 help for firmware
+  -f, --firmware string   [required] ID of the firmware
+  -h, --help              help for firmware
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
-  -o, --output string   {json|text} (default "json")
-      --reauth          re-authenticate with oauth services
+  -c, --config string       config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
+  -o, --output outputType   {json|text} (default json)
+      --reauth              re-authenticate with oauth services
 ```
 
 ### SEE ALSO

--- a/docs/mctl_get_server.md
+++ b/docs/mctl_get_server.md
@@ -5,27 +5,27 @@
 Get server information
 
 ```
-mctl get server [flags]
+mctl get server -s SERVER [flags]
 ```
 
 ### Options
 
 ```
-  -b, --bioscfg            print bios configuration
-      --component string   list component on server by slug (drive/nic/cpu..)
-      --creds              include BMC credentials in result
-  -h, --help               help for server
-      --id string          server UUID
-  -l, --list-components    include component data
-  -t, --table              format output in a table
+      --bios-config       print bios configuration
+  -h, --help              help for server
+      --list-components   include component data
+  -s, --server string     [required] ID of the server
+      --slug string       list component on server by slug (drive/nic/cpu..)
+      --table             format output in a table
+      --with-creds        include credentials
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
-  -o, --output string   {json|text} (default "json")
-      --reauth          re-authenticate with oauth services
+  -c, --config string       config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
+  -o, --output outputType   {json|text} (default json)
+      --reauth              re-authenticate with oauth services
 ```
 
 ### SEE ALSO

--- a/docs/mctl_install.md
+++ b/docs/mctl_install.md
@@ -17,7 +17,7 @@ mctl install [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
+  -c, --config string   config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
       --reauth          re-authenticate with oauth services
 ```
 

--- a/docs/mctl_install_firmware-set.md
+++ b/docs/mctl_install_firmware-set.md
@@ -5,25 +5,25 @@
 Install firmware set
 
 ```
-mctl install firmware-set [flags]
+mctl install firmware-set -s SERVER [flags]
 ```
 
 ### Options
 
 ```
-      --dry-run                    Run install process in dry-run (skips firmware install)
-      --force                      force install (skips firmware version check)
-  -h, --help                       help for firmware-set
-      --id string                  firmware set UUID
-      --require-host-powered-off   require host to be powered off before proceeding install
-      --server string              server UUID
-      --skip-bmc-reset             skip BMC reset before firmware install
+      --dry-run              Run install process in dry-run (skips firmware install)
+      --force                force install (skips firmware version check)
+  -h, --help                 help for firmware-set
+      --power-off-required   require host to be powered off before proceeding install
+  -s, --server string        [required] ID of the server
+      --set-id string        ID of the firmware set
+      --skip-bmc-reset       skip BMC reset before firmware install
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
+  -c, --config string   config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
       --reauth          re-authenticate with oauth services
 ```
 

--- a/docs/mctl_install_status.md
+++ b/docs/mctl_install_status.md
@@ -5,20 +5,20 @@
 check the progress of a firmware install on a server
 
 ```
-mctl install status --server | -s <server uuid> [flags]
+mctl install status --server | -s <server uuid> -s SERVER [flags]
 ```
 
 ### Options
 
 ```
   -h, --help            help for status
-  -s, --server string   server id (typically a UUID)
+  -s, --server string   [required] ID of the server
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
+  -c, --config string   config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
       --reauth          re-authenticate with oauth services
 ```
 

--- a/docs/mctl_list.md
+++ b/docs/mctl_list.md
@@ -11,14 +11,14 @@ mctl list [flags]
 ### Options
 
 ```
-  -h, --help          help for list
-      --output-json   Output listing as JSON
+  -h, --help                help for list
+  -o, --output outputType   {json|text} (default json)
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
+  -c, --config string   config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
       --reauth          re-authenticate with oauth services
 ```
 

--- a/docs/mctl_list_component.md
+++ b/docs/mctl_list_component.md
@@ -5,7 +5,7 @@
 List Components
 
 ```
-mctl list component [flags]
+mctl list component --slug SLUG [flags]
 ```
 
 ### Options
@@ -13,19 +13,19 @@ mctl list component [flags]
 ```
   -h, --help            help for component
       --limit int       limit results returned (default 10)
-      --model string    filter by one or more component models
+  -m, --model string    filter by model
       --page int        limit results to page (for use with --limit)
-      --records         print record count found with pagination info and return
-      --slug string     filter by component slug (nic/drive/bmc/bios...)
-      --vendor string   filter by component vendor
+      --slug string     [required] filter by component slug (nic/drive/bmc/bios...)
+  -v, --vendor string   filter by vendor
+      --with-records    print record count found with pagination info and return
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
-      --output-json     Output listing as JSON
-      --reauth          re-authenticate with oauth services
+  -c, --config string       config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
+  -o, --output outputType   {json|text} (default json)
+      --reauth              re-authenticate with oauth services
 ```
 
 ### SEE ALSO

--- a/docs/mctl_list_firmware-set.md
+++ b/docs/mctl_list_firmware-set.md
@@ -12,16 +12,16 @@ mctl list firmware-set [flags]
 
 ```
   -h, --help            help for firmware-set
-      --model string    filter by server model
-      --vendor string   filter by server vendor
+  -m, --model string    filter by model
+  -v, --vendor string   filter by vendor
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
-      --output-json     Output listing as JSON
-      --reauth          re-authenticate with oauth services
+  -c, --config string       config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
+  -o, --output outputType   {json|text} (default json)
+      --reauth              re-authenticate with oauth services
 ```
 
 ### SEE ALSO

--- a/docs/mctl_list_firmware.md
+++ b/docs/mctl_list_firmware.md
@@ -22,9 +22,9 @@ mctl list firmware [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
-      --output-json     Output listing as JSON
-      --reauth          re-authenticate with oauth services
+  -c, --config string       config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
+  -o, --output outputType   {json|text} (default json)
+      --reauth              re-authenticate with oauth services
 ```
 
 ### SEE ALSO

--- a/docs/mctl_list_server.md
+++ b/docs/mctl_list_server.md
@@ -11,25 +11,25 @@ mctl list server [flags]
 ### Options
 
 ```
-      --bmcerrors         list servers with BMC errors
-      --creds             list BMC credentials in 
-      --facility string   filter by facility code
+      --facility string   facility name
   -h, --help              help for server
       --limit int         limit results returned (default 10)
-      --model string      filter by server model
+  -m, --model string      filter by model
       --page int          limit results to page (for use with --limit)
-      --records           only print record count matching filters
       --serial string     filter by server serial
-      --table             print records in a table format
-      --vendor string     filter by server vendor
+      --table             format output in a table
+  -v, --vendor string     filter by vendor
+      --with-bmc-errors   include BMC errors
+      --with-creds        include credentials
+      --with-records      print record count found with pagination info and return
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
-      --output-json     Output listing as JSON
-      --reauth          re-authenticate with oauth services
+  -c, --config string       config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
+  -o, --output outputType   {json|text} (default json)
+      --reauth              re-authenticate with oauth services
 ```
 
 ### SEE ALSO

--- a/docs/mctl_version.md
+++ b/docs/mctl_version.md
@@ -17,7 +17,7 @@ mctl version [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
+  -c, --config string   config file (default is $XDG_CONFIG_HOME/mctl/config.yml)
       --reauth          re-authenticate with oauth services
 ```
 


### PR DESCRIPTION
The mcli commands have inconsistencies and contradictions in their flag usages.

This change moves all of the CLI flags under a single `flags.go` file. Centralizing the flags will allows us to easily see all flags in use, which helps when creating or updating flags. The functions for adding flags encourages flag reuse, which helps with consistency.

I think some flags may still need refactoring. For example, the flags for getting and listing servers looks like it could use a cleanup.