### PR TITLE
get/firmware-set: Fix for mutually exclusive flags

### DIFF
--- a/cmd/get/firmware-set.go
+++ b/cmd/get/firmware-set.go
@@ -116,5 +116,5 @@ func init() {
 	mctl.AddServerFlag(getFirmwareSet, &flagsDefinedGetFirmwareSet.serverID)
 	mctl.AddFirmwareSetFlag(getFirmwareSet, &flagsDefinedGetFirmwareSet.id)
 
-	mctl.RequireFlag(getFirmwareSet, mctl.ServerFlag)
+	mctl.MutuallyExclusiveFlags(getFirmwareSet, mctl.ServerFlag, mctl.FirmwareSetFlag)
 }

--- a/docs/mctl_get_firmware-set.md
+++ b/docs/mctl_get_firmware-set.md
@@ -5,14 +5,14 @@
 Get information for given firmware set identifier
 
 ```
-mctl get firmware-set -s SERVER [flags]
+mctl get firmware-set [flags]
 ```
 
 ### Options
 
 ```
   -h, --help            help for firmware-set
-  -s, --server string   [required] ID of the server
+  -s, --server string   ID of the server
       --set-id string   ID of the firmware set
 ```
 


### PR DESCRIPTION
During the refactor to standardize all flags, the flags for get firmware-set was inadvertently switch from being mutually exclusive to requried. This change makes the flags mutually exclusive again.