### PR TITLE
list/component: filter by component firmware version

### DIFF
--- a/cmd/list/component.go
+++ b/cmd/list/component.go
@@ -17,7 +17,6 @@ type listComponentFlags struct {
 	serial    string
 	model     string
 	fwVersion string
-	health    string
 	records   bool
 	limit     int
 	page      int

--- a/docs/mctl_list_component.md
+++ b/docs/mctl_list_component.md
@@ -11,13 +11,14 @@ mctl list component --slug SLUG [flags]
 ### Options
 
 ```
-  -h, --help            help for component
-      --limit int       limit results returned. Max value is 1000 (hard limit set in fleetdb). To list more than 1000, you must query each page (with '--page') individually (default 10)
-  -m, --model string    filter by model
-      --page int        limit results to page (for use with --limit)
-      --slug string     [required] filter by component slug (nic/drive/bmc/bios...)
-  -v, --vendor string   filter by vendor
-      --with-records    print record count found with pagination info and return
+  -V, --firmware-version string   firmware version
+  -h, --help                      help for component
+      --limit int                 limit results returned. Max value is 1000 (hard limit set in fleetdb). To list more than 1000, you must query each page (with '--page') individually (default 10)
+  -m, --model string              filter by model
+      --page int                  limit results to page (for use with --limit)
+      --slug string               [required] filter by component slug (nic/drive/bmc/bios...)
+  -v, --vendor string             filter by vendor
+      --with-records              print record count found with pagination info and return
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
This helps to search across components with a given firmware version,
`mctl list component --vendor dell --slug bmc -V 4.20 --with-records`