### PR TITLE
Add mctl curl support for fleetdb

### DIFF
--- a/cmd/curl.go
+++ b/cmd/curl.go
@@ -1,0 +1,66 @@
+package cmd
+
+// Adopted from an internal tool, credits to those unnamed authors.
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"slices"
+	"syscall"
+
+	"github.com/metal-toolbox/mctl/internal/app"
+	"github.com/metal-toolbox/mctl/internal/auth"
+	"github.com/metal-toolbox/mctl/pkg/model"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+// curlCmd represents the curl command
+var curlCmd = &cobra.Command{
+	Use:   "curl fleetdbapi -- args",
+	Short: "Make a curl request with your auth token",
+	Args:  cobra.MinimumNArgs(2), // nolint:gomnd
+	Run: func(cmd *cobra.Command, args []string) {
+		apiKind := args[0]
+		if !slices.Contains(
+			[]string{string(model.FleetDBAPI)},
+			apiKind,
+		) {
+			log.Fatal("invalid service parameter: " + apiKind)
+		}
+
+		curlArgs := args[1:]
+		doCurl(cmd.Context(), model.APIKind(apiKind), curlArgs)
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(curlCmd)
+}
+
+func doCurl(ctx context.Context, _ model.APIKind, args []string) {
+	mctl := MustCreateApp(ctx)
+	ctx, cancel := context.WithTimeout(ctx, CmdTimeout)
+	defer cancel()
+
+	token, err := auth.AccessToken(ctx, model.FleetDBAPI, mctl.Config.FleetDBAPI, false)
+	if err != nil {
+		log.Fatal(errors.Wrap(app.ErrAuth, string(model.FleetDBAPI)+err.Error()))
+	}
+
+	binary, lookErr := exec.LookPath("curl")
+	if lookErr != nil {
+		panic(lookErr)
+	}
+
+	cmd := []string{"curl", "-H", fmt.Sprintf("Authorization: Bearer %s", token)}
+	cmd = append(cmd, args...)
+
+	// syscall.Exec changes the current running process to curl.
+	// this allows curl to take over the same pid and allows us to exit
+	if err := syscall.Exec(binary, cmd, os.Environ()); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/cmd/curl.go
+++ b/cmd/curl.go
@@ -10,10 +10,8 @@ import (
 	"slices"
 	"syscall"
 
-	"github.com/metal-toolbox/mctl/internal/app"
 	"github.com/metal-toolbox/mctl/internal/auth"
 	"github.com/metal-toolbox/mctl/pkg/model"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -47,7 +45,8 @@ func doCurl(ctx context.Context, _ model.APIKind, args []string) {
 
 	token, err := auth.AccessToken(ctx, model.FleetDBAPI, mctl.Config.FleetDBAPI, false)
 	if err != nil {
-		log.Fatal(errors.Wrap(app.ErrAuth, string(model.FleetDBAPI)+err.Error()))
+		// nolint:gocritic // its fine if the ctx is not cleaned up we're exiting the app.
+		log.Fatal("auth token error: " + err.Error())
 	}
 
 	binary, lookErr := exec.LookPath("curl")

--- a/docs/mctl.md
+++ b/docs/mctl.md
@@ -18,6 +18,7 @@ mctl is a CLI utility to interact with metal toolbox services
 * [mctl collect](mctl_collect.md)	 - Collect current server firmware status and bios configuration
 * [mctl completion](mctl_completion.md)	 - Generate the autocompletion script for the specified shell
 * [mctl create](mctl_create.md)	 - Create resources
+* [mctl curl](mctl_curl.md)	 - Make a curl request with your auth token
 * [mctl delete](mctl_delete.md)	 - Delete resources
 * [mctl edit](mctl_edit.md)	 - Edit resources
 * [mctl gendocs](mctl_gendocs.md)	 - Generate markdown docs for mctl CLI


### PR DESCRIPTION
Support  curl commands on fleetdb API

Query intel drives
```
❯ ./mctl curl fleetdbapi -- "https://fleetdb/api/v1/servers/components?limit=1&sc_0%5Btype%5D=drive&sc_0%5Bvendor%5D=intel"

{"page_size":1,"page":1,"page_count":1,....}
```

Query drive capabilities
```
./mctl curl fleetdbapi -- -g "https://fleetdb/api/v1/servers/components?sc_0[type]=drive&sc0_attr=sh.hollow.alloy.inband.metadata&limit=1&page=1"
```