### PR TITLE
Set list limit to 100 BMS-1254

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -265,7 +265,7 @@ func AddPageFlag(cmd *cobra.Command, ptr *int) {
 }
 
 func AddPageLimitFlag(cmd *cobra.Command, ptr *int) {
-	defaultLimit := 10
+	defaultLimit := 100
 	usage := fmt.Sprintf("limit results returned. Max value is %d (hard limit set in fleetdb). To list more than %d, you must query each page (with '--page') individually", fleetdbapi.MaxPaginationSize, fleetdbapi.MaxPaginationSize)
 
 	cmd.PersistentFlags().IntVar(ptr, LimitFlag.name, defaultLimit, usage)

--- a/docs/mctl_list_component.md
+++ b/docs/mctl_list_component.md
@@ -13,7 +13,7 @@ mctl list component --slug SLUG [flags]
 ```
   -V, --firmware-version string   firmware version
   -h, --help                      help for component
-      --limit int                 limit results returned. Max value is 1000 (hard limit set in fleetdb). To list more than 1000, you must query each page (with '--page') individually (default 10)
+      --limit int                 limit results returned. Max value is 1000 (hard limit set in fleetdb). To list more than 1000, you must query each page (with '--page') individually (default 100)
   -m, --model string              filter by model
       --page int                  limit results to page (for use with --limit)
       --slug string               [required] filter by component slug (nic/drive/bmc/bios...)

--- a/docs/mctl_list_firmware.md
+++ b/docs/mctl_list_firmware.md
@@ -14,7 +14,7 @@ mctl list firmware [flags]
       --component string          the component type or slug (bmc|bios|nic..)
   -V, --firmware-version string   firmware version
   -h, --help                      help for firmware
-      --limit int                 limit results returned. Max value is 1000 (hard limit set in fleetdb). To list more than 1000, you must query each page (with '--page') individually (default 10)
+      --limit int                 limit results returned. Max value is 1000 (hard limit set in fleetdb). To list more than 1000, you must query each page (with '--page') individually (default 100)
   -m, --model string              filter by model
       --page int                  limit results to page (for use with --limit)
   -v, --vendor string             filter by vendor

--- a/docs/mctl_list_server.md
+++ b/docs/mctl_list_server.md
@@ -13,7 +13,7 @@ mctl list server [flags]
 ```
       --facility string   facility name
   -h, --help              help for server
-      --limit int         limit results returned. Max value is 1000 (hard limit set in fleetdb). To list more than 1000, you must query each page (with '--page') individually (default 10)
+      --limit int         limit results returned. Max value is 1000 (hard limit set in fleetdb). To list more than 1000, you must query each page (with '--page') individually (default 100)
   -m, --model string      filter by model
       --page int          limit results to page (for use with --limit)
       --serial string     filter by server serial


### PR DESCRIPTION
Currently, listing firmwares/firmware-sets/etc. is limited to 10 results which is too low as a useful default. This PR sets it to 100.