### PR TITLE
Add basic support for managing server bios configsets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,20 @@ endif
 		 -X ${LDFLAG_LOCATION}.AppVersion=${VERSION} \
 		 -X ${LDFLAG_LOCATION}.BuildDate=${BUILD_DATE}"
 
+## build windows bin
+build-windows:
+ifeq (${GO_VERSION}, 0)
+	$(error build requies go version 1.17.n or higher)
+endif
+	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -o mctl \
+		-ldflags \
+		"-X ${LDFLAG_LOCATION}.GitCommit=${GIT_COMMIT} \
+		 -X ${LDFLAG_LOCATION}.GitBranch=${GIT_BRANCH} \
+		 -X ${LDFLAG_LOCATION}.GitSummary=${GIT_SUMMARY} \
+		 -X ${LDFLAG_LOCATION}.AppVersion=${VERSION} \
+		 -X ${LDFLAG_LOCATION}.BuildDate=${BUILD_DATE}"
+
+
 ## Generate CLI docs
 gen-docs:
 	CGO_ENABLED=0 go build -o mctl

--- a/cmd/create/create.go
+++ b/cmd/create/create.go
@@ -20,4 +20,5 @@ func init() {
 	create.AddCommand(createFirmwareSet)
 	create.AddCommand(uploadBomFile)
 	create.AddCommand(serverEnroll)
+	create.AddCommand(createServerBiosConfigSet)
 }

--- a/cmd/create/server_bios_config_set.go
+++ b/cmd/create/server_bios_config_set.go
@@ -1,0 +1,67 @@
+package create
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+	"os"
+
+	fleetdbapi "github.com/metal-toolbox/fleetdb/pkg/api/v1"
+	mctl "github.com/metal-toolbox/mctl/cmd"
+	"github.com/metal-toolbox/mctl/internal/app"
+	"github.com/spf13/cobra"
+)
+
+var fromFile string
+
+var createServerBiosConfigSet = &cobra.Command{
+	Use:   "bios-config-set",
+	Short: "Create a bios config set",
+	PreRun: func(cmd *cobra.Command, _ []string) {
+		fromFile, err := cmd.Flags().GetString(mctl.FromFileFlag.Name())
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		if fromFile == "" {
+			mctl.RequireFlag(cmd, mctl.FromFileFlag)
+		}
+	},
+	Run: func(cmd *cobra.Command, _ []string) {
+		theApp := mctl.MustCreateApp(cmd.Context())
+
+		client, err := app.NewFleetDBAPIClient(cmd.Context(), theApp.Config.FleetDBAPI, theApp.Reauth)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		err = createServerBiosConfigSetFromFile(cmd.Context(), client)
+		if err != nil {
+			log.Fatal(err)
+		}
+	},
+}
+
+func createServerBiosConfigSetFromFile(ctx context.Context, client *fleetdbapi.Client) (err error) {
+	biosconfigset := &fleetdbapi.BiosConfigSet{}
+
+	fbytes, err := os.ReadFile(fromFile)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if err = json.Unmarshal(fbytes, &biosconfigset); err != nil {
+		log.Fatal(err)
+	}
+
+	_, err = client.CreateServerBiosConfigSet(ctx, *biosconfigset)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	return nil
+}
+
+func init() {
+	mctl.AddFromFileFlag(createServerBiosConfigSet, &fromFile, "path to JSON file containing bios config set")
+}

--- a/cmd/delete/delete.go
+++ b/cmd/delete/delete.go
@@ -19,4 +19,5 @@ func init() {
 	deleteCmd.AddCommand(deleteFirmwareSet)
 	deleteCmd.AddCommand(deleteFirmware)
 	deleteCmd.AddCommand(serverDelete)
+	deleteCmd.AddCommand(deleteServerBiosConfigSet)
 }

--- a/cmd/delete/server_bios_config_set.go
+++ b/cmd/delete/server_bios_config_set.go
@@ -1,0 +1,43 @@
+package deleteresource
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/google/uuid"
+	"github.com/metal-toolbox/mctl/internal/app"
+	"github.com/spf13/cobra"
+
+	mctl "github.com/metal-toolbox/mctl/cmd"
+)
+
+var deleteServerBiosConfigSetID string
+
+var deleteServerBiosConfigSet = &cobra.Command{
+	Use:   "bios-config-set",
+	Short: "Delete a bios config set",
+	Run: func(cmd *cobra.Command, _ []string) {
+		theApp := mctl.MustCreateApp(cmd.Context())
+
+		client, err := app.NewFleetDBAPIClient(cmd.Context(), theApp.Config.FleetDBAPI, theApp.Reauth)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		id, err := uuid.Parse(deleteServerBiosConfigSetID)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		_, err = client.DeleteServerBiosConfigSet(cmd.Context(), id)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		fmt.Println("bios config set deleted: " + id.String())
+	},
+}
+
+func init() {
+	mctl.AddBIOSConfigSetIDFlag(deleteServerBiosConfigSet, &deleteServerBiosConfigSetID)
+}

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -61,6 +61,7 @@ var (
 	ServerActionPowerActionStatusFlag = &flagDetails{name: "action-status"}
 	ComponentTypeFlag                 = &flagDetails{name: "component"}
 	BIOSConfigURLFlag                 = &flagDetails{name: "bios-config-url"}
+	BIOSConfigSetIDFlag               = &flagDetails{name: "bios-config-set-id", short: "i"}
 
 	OutputTypeJSON outputType = "json"
 	OutputTypeText outputType = "text"
@@ -297,6 +298,10 @@ func AddComponentTypeFlag(cmd *cobra.Command, ptr *string) {
 
 func AddServerSerialFlag(cmd *cobra.Command, ptr *string) {
 	cmd.PersistentFlags().StringVar(ptr, ServerSerialFlag.name, "", "filter by server serial")
+}
+
+func AddBIOSConfigSetIDFlag(cmd *cobra.Command, ptr *string) {
+	cmd.PersistentFlags().StringVarP(ptr, BIOSConfigSetIDFlag.name, BIOSConfigSetIDFlag.short, "", "specify ID of Bios Config Set")
 }
 
 func AddServerPowerActionFlag(cmd *cobra.Command, ptr *string, params []string) {

--- a/cmd/list/list.go
+++ b/cmd/list/list.go
@@ -24,6 +24,7 @@ func init() {
 	list.AddCommand(listFirmwareSet)
 	list.AddCommand(listComponent)
 	list.AddCommand(cmdListServer)
+	list.AddCommand(listServerBiosConfigSet)
 
 	cmd.AddOutputFlag(list, &output)
 }

--- a/cmd/list/server_bios_config_set.go
+++ b/cmd/list/server_bios_config_set.go
@@ -1,0 +1,72 @@
+package list
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+
+	fleetdbapi "github.com/metal-toolbox/fleetdb/pkg/api/v1"
+	mctl "github.com/metal-toolbox/mctl/cmd"
+	"github.com/metal-toolbox/mctl/internal/app"
+	"github.com/olekukonko/tablewriter"
+	"github.com/spf13/cobra"
+)
+
+//nolint:err113 // brevity is best here
+func sendListServerBiosConfigSetRequest(client *fleetdbapi.Client, cmd *cobra.Command) (*[]fleetdbapi.BiosConfigSet, error) {
+	params := &fleetdbapi.BiosConfigSetListParams{
+		Pagination: fleetdbapi.PaginationParams{
+			Preload: true,
+		},
+	}
+
+	biosConfig, err := client.ListServerBiosConfigSet(context.Background(), params)
+	if err != nil {
+		return nil, fmt.Errorf("retrieving bios configs: %w", err)
+	}
+
+	if biosConfig.TotalRecordCount == 0 {
+		return nil, errors.New("no bios configs identified")
+	}
+
+	return biosConfig.Records.(*[]fleetdbapi.BiosConfigSet), nil
+}
+
+// List
+var listServerBiosConfigSet = &cobra.Command{
+	Use:   "bios-config-set",
+	Short: "List bios config",
+	Run: func(cmd *cobra.Command, _ []string) {
+		theApp := mctl.MustCreateApp(cmd.Context())
+
+		client, err := app.NewFleetDBAPIClient(cmd.Context(), theApp.Config.FleetDBAPI, theApp.Reauth)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		biosConfig, err := sendListServerBiosConfigSetRequest(client, cmd)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		if output == mctl.OutputTypeJSON.String() {
+			printJSON(biosConfig)
+			os.Exit(0)
+		}
+
+		table := tablewriter.NewWriter(os.Stdout)
+		table.SetHeader([]string{"ID", "Name", "Version"})
+		for _, s := range *biosConfig {
+			table.Append([]string{s.ID, s.Name, s.Version})
+		}
+
+		table.SetAutoMergeCells(true)
+		table.Render()
+	},
+}
+
+func init() {
+
+}

--- a/samples/mctl-disable-auth.yml
+++ b/samples/mctl-disable-auth.yml
@@ -1,4 +1,8 @@
-disable_oauth: true
-serverservice_endpoint: http://localhost:8000
-conditions_endpoint: http://localhost:9000
-bomservice_endpoint: http://localhost:9003
+---
+serverservice_api:
+  endpoint: http://localhost:8000
+  disable: true
+
+conditions_api:
+  endpoint: http://localhost:8001
+  disable: true


### PR DESCRIPTION
This PR adds some basic controls to create, list and delete server bios config sets. Also contains some updates to enable building for windows and a mctl config for testing locally.